### PR TITLE
Fixed circular loop detection in SCVLoggingUtil

### DIFF
--- a/contactLensConsumer/SCVLoggingUtil.js
+++ b/contactLensConsumer/SCVLoggingUtil.js
@@ -146,6 +146,8 @@ function createLoggingMessage(
       if (typeof value === "object" && value !== null) {
         if (seen.has(value)) {
           return undefined;
+        } else {
+          seen.add(value);
         }
       }
       return value;

--- a/ctrDataSync/SCVLoggingUtil.js
+++ b/ctrDataSync/SCVLoggingUtil.js
@@ -145,6 +145,8 @@ function createLoggingMessage(
       if (typeof value === "object" && value !== null) {
         if (seen.has(value)) {
           return undefined;
+        } else {
+          seen.add(value);
         }
       }
       return value;

--- a/handleContactEvents/SCVLoggingUtil.js
+++ b/handleContactEvents/SCVLoggingUtil.js
@@ -145,6 +145,8 @@ function createLoggingMessage(
       if (typeof value === "object" && value !== null) {
         if (seen.has(value)) {
           return undefined;
+        } else {
+          seen.add(value);
         }
       }
       return value;

--- a/invokeSfRestApi/SCVLoggingUtil.js
+++ b/invokeSfRestApi/SCVLoggingUtil.js
@@ -145,6 +145,8 @@ function createLoggingMessage(
       if (typeof value === "object" && value !== null) {
         if (seen.has(value)) {
           return undefined;
+        } else {
+          seen.add(value);
         }
       }
       return value;

--- a/invokeTelephonyIntegrationApi/SCVLoggingUtil.js
+++ b/invokeTelephonyIntegrationApi/SCVLoggingUtil.js
@@ -145,6 +145,8 @@ function createLoggingMessage(
       if (typeof value === "object" && value !== null) {
         if (seen.has(value)) {
           return undefined;
+        } else {
+          seen.add(value);
         }
       }
       return value;

--- a/kvsConsumerTrigger/SCVLoggingUtil.js
+++ b/kvsConsumerTrigger/SCVLoggingUtil.js
@@ -145,6 +145,8 @@ function createLoggingMessage(
       if (typeof value === "object" && value !== null) {
         if (seen.has(value)) {
           return undefined;
+        } else {
+          seen.add(value);
         }
       }
       return value;


### PR DESCRIPTION
The SCVLoggingUtil.js file (which is duplicated in several of the lambda functions in this repository), has a logical error in the `getCircularReplacer` function which is used in error logging. This error prevents the circular replace from functioning correctly, resulting in secondary exceptions whenever the primary error context contains a circular structure. 

This function corrects the logical issue so that the circular replace works as originally intended, preventing secondary errors so the primary exception is correctly logged. 