### PR TITLE
Fix environment variable formatting for CTR data sync function

### DIFF
--- a/ServerlessApplication/ServiceCloudVoiceLambdas.yaml
+++ b/ServerlessApplication/ServiceCloudVoiceLambdas.yaml
@@ -295,7 +295,7 @@ Resources:
       Timeout: 30
       Environment:
         Variables:
-          transcriptionFunction: !GetAtt kvsTranscriber.Arn
+          INVOKE_KVS_TRANSCRIBER_ARN: !GetAtt kvsTranscriber.Arn
           LOG_LEVEL: "info"
       Layers:
         - Ref: kvsConsumerTriggerFunctionLayer

--- a/kvsConsumerTrigger/kvs_trigger.js
+++ b/kvsConsumerTrigger/kvs_trigger.js
@@ -75,7 +75,7 @@ exports.handler = (event, context, callback) => {
 
   const params = {
     // not passing in a ClientContext
-    FunctionName: process.env.transcriptionFunction,
+    FunctionName: process.env.INVOKE_KVS_TRANSCRIBER_ARN,
     // InvocationType is RequestResponse by default
     // LogType is not set so we won't get the last 4K of logs from the invoked function
     // Qualifier is not set so we use $LATEST


### PR DESCRIPTION
It seems wrong the current `kvsConsumerTrigger` Lambda function uses an environment variable in the following format of `kvsConsumerTrigger` - rather than `SNAKE_CASE` as per others.

This renaming scheme brings it inline with the `INVOKE_TELEPHONY_INTEGRATION_API_ARN` style used with the `CTRDataSyncFunction` and `HandleContactEventsFunction` Lambda functions.
