### PR TITLE
Removed the repo-specific CODEOWNERS

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,2 +1,0 @@
-# Comment line immediately above ownership line is reserved for related gus information. Please be careful while editing.
-#ECCN:Open Source


### PR DESCRIPTION
Removed the repo-specific CODEOWNERS to use the org-level [override](https://github.com/service-cloud-voice/sfdc-codeowners/blob/ffcc6a568c55f36310a4bfdcdb095e309638ad45/sfdc-codeowners-uo/CODEOWNERS) instead.