### PR TITLE
parameterize sf auth endpoint and rest api

### DIFF
--- a/ServerlessApplication/ServiceCloudVoiceLambdas.yaml
+++ b/ServerlessApplication/ServiceCloudVoiceLambdas.yaml
@@ -54,12 +54,18 @@ Parameters:
     Type: String
     Default: service-cloud-voice-contact-center-id
     Description: Connect Instance Id.
+  SalesforceAuthEndpoint:
+    Type: String
+    Default: https://login.salesforce.com/services/oauth2/token
+    Description: The authentication endpoint for Salesforce organisation and environment.
+  SalesforceRestApiEndpointBase:
+    Type: String
+    Default: https://login.salesforce.com/services/data/v54.0
+    Description: The endpoint for the organisational Salesforce REST API.
   PermissionBoundaryARN:
     Default: ''
     Type: String
     Description: IAM Permission Boundary ARN as defined by the admin
-
-
 
 Conditions:
   CreatePermissionBoundary: 
@@ -197,8 +203,8 @@ Resources:
           ACCESS_TOKEN_PARAM_NAME: !Sub ${SalesforceRestApiAccessTokenSSMParamName}
           SUBJECT: !Sub ${SalesforceRestApiSubjectSSMParamName}
           AUDIENCE: !Sub ${SalesforceRestApiAudienceSSMParamName}
-          SALESFORCE_AUTH_ENDPOINT: https://login.salesforce.com/services/oauth2/token
-          SALESFORCE_REST_API_ENDPOINT_BASE: https://login.salesforce.com/services/data/v54.0
+          SALESFORCE_AUTH_ENDPOINT: !Sub ${SalesforceAuthEndpoint}
+          SALESFORCE_REST_API_ENDPOINT_BASE: !Sub ${SalesforceRestApiEndpointBase}
           LOG_LEVEL: "info"
       Policies:
         - Statement:


### PR DESCRIPTION
**DESCRIPTION**

This PR adds the ability to configure the `InvokeSalesforceRestApiFunction` with organisation specific AUTH and REST API endpoints at the time of stack initiation rather than have to configure these values post deployment. The original defaults are kept. 

This makes it easier to configure everything at stack initiation time and drive everything from infrastructure as code tools like terraform, pulumi etc. 

By way of example; here is a Terraform use case. Referencing https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/serverlessapplicationrepository_cloudformation_stack

We can see how easily one can spin up this Cloud Formation stack from SAR with the correct parameters in an Infrastructure as Code paradigm.


```
resource "aws_serverlessapplicationrepository_cloudformation_stack" "service_cloud_voice" {
  name           = "ServiceCloudVoice"
  application_id = "arn:aws:serverlessrepo:us-east-1:317368162107:applications/ServiceCloudVoiceLambdas"
  capabilities = [
    "CAPABILITY_NAMED_IAM",
    "CAPABILITY_RESOURCE_POLICY",
  ]
  parameters = {
    SalesforceOrgId                = var.salesforce_org_id
    SalesforceS3BucketForVoiceMail = var.s3_voice_mail_bucket_name
    ConnectInstanceId              = var.connect_instance_id
    SalesforceAuthEndpoint     =  var.salesforce_auth_endpoint
    SalesforceRestApiEndpointBase = var.salesforce_rest_api_endpoint_base
  }
  semantic_version = "12.0.0"
  tags             = var.tags
}
```