### PR TITLE
set VoiceMailPackagingFunction Timeout 300

### DIFF
--- a/ServerlessApplication/ServiceCloudVoiceLambdas.yaml
+++ b/ServerlessApplication/ServiceCloudVoiceLambdas.yaml
@@ -1449,7 +1449,7 @@ Resources:
           invoke_telephony_integration_api_arn: !GetAtt InvokeTelephonyIntegrationApiFunction.Arn
           LOG_LEVEL: "info"
       Role: !GetAtt VoiceMailPackagingFunctionRole.Arn
-      Timeout: 60
+      Timeout: 300
       Layers:
         - Ref: VoiceMailPackagingFunctionLayer
 


### PR DESCRIPTION
**DESCRIPTION**

This PR raises the default Timeout for the VoiceMailPackagingFunction due to the fact that the function in question is a long running function by default - it has a purposeful delay within it and the current default combination does not seem sensible. The linked issue below describes the problem in further detail.

Partially addresses #43 