### PR TITLE
fix: updateRecord returns success:false for successful PATCH (204 No Content)

### DIFF
--- a/invokeSfRestApi/sfRestApi.js
+++ b/invokeSfRestApi/sfRestApi.js
@@ -95,14 +95,9 @@ async function updateRecord(objectApiName, recordId, fieldValues, secretName, ac
       message: "update Record response",
       context: response,
     });
-    if (response.data === "") {
-      return {
-        success: true,
-      };
-    }
-    return {
-      success: false,
-    };
+    // Salesforce returns 204 No Content on a successful PATCH.
+    // axios throws on non-2xx, so reaching here always means success.
+    return { success: true };
   } catch (e) {
     return buildError(e);
   }

--- a/invokeSfRestApi/tests/sfRestApi.test.js
+++ b/invokeSfRestApi/tests/sfRestApi.test.js
@@ -98,33 +98,52 @@ describe("createRecord", () => {
 });
 
 describe("updateRecord", () => {
-  it("updates a record sucessfully using the api", async () => {
-    const data = "";
-    const configs = {
-      callCenterApiName: "callCenterApiNameVal",
-      baseURL: "baseURLVal",
-      authEndpoint: "authEndpointVal",
-      consumerKey: "consumerKeyVal",
-      privateKey: "privateKeyVal",
-      audience: "audienceVal",
-      subject: "subjectVal"
-    };
+  const configs = {
+    callCenterApiName: "callCenterApiNameVal",
+    baseURL: "baseURLVal",
+    authEndpoint: "authEndpointVal",
+    consumerKey: "consumerKeyVal",
+    privateKey: "privateKeyVal",
+    audience: "audienceVal",
+    subject: "subjectVal"
+  };
 
+  const successResponse = { success: true };
+
+  it("updates a record successfully when response data is empty string (204 No Content)", async () => {
     secretUtils.getSecretConfigs.mockImplementationOnce(() => Promise.resolve(configs));
-    utils.getAccessToken.mockImplementationOnce(() =>
-      Promise.resolve("test1234")
-    );
+    utils.getAccessToken.mockImplementationOnce(() => Promise.resolve("test1234"));
     axiosWrapper.apiEndpoint.mockImplementationOnce(() =>
       Promise.resolve({ data: "" })
     );
 
-    const responseData = {
-      success: true,
-    };
+    await expect(
+      await api.updateRecord("Account", "1234", { Name: "Test Account 1" })
+    ).toEqual(successResponse);
+  });
+
+  it("updates a record successfully when response data is null (204 No Content)", async () => {
+    secretUtils.getSecretConfigs.mockImplementationOnce(() => Promise.resolve(configs));
+    utils.getAccessToken.mockImplementationOnce(() => Promise.resolve("test1234"));
+    axiosWrapper.apiEndpoint.mockImplementationOnce(() =>
+      Promise.resolve({ data: null })
+    );
 
     await expect(
-      await api.updateRecord(("Account", "1234", { Name: "Test Account 1" }))
-    ).toEqual(responseData);
+      await api.updateRecord("Account", "1234", { Name: "Test Account 1" })
+    ).toEqual(successResponse);
+  });
+
+  it("updates a record successfully when response data is undefined (204 No Content)", async () => {
+    secretUtils.getSecretConfigs.mockImplementationOnce(() => Promise.resolve(configs));
+    utils.getAccessToken.mockImplementationOnce(() => Promise.resolve("test1234"));
+    axiosWrapper.apiEndpoint.mockImplementationOnce(() =>
+      Promise.resolve({ data: undefined })
+    );
+
+    await expect(
+      await api.updateRecord("Account", "1234", { Name: "Test Account 1" })
+    ).toEqual(successResponse);
   });
 
   it("updates a record on an erroneous object using the api", async () => {
@@ -141,23 +160,10 @@ describe("updateRecord", () => {
         ],
       },
     };
-    const configs = {
-      callCenterApiName: "callCenterApiNameVal",
-      baseURL: "baseURLVal",
-      authEndpoint: "authEndpointVal",
-      consumerKey: "consumerKeyVal",
-      privateKey: "privateKeyVal",
-      audience: "audienceVal",
-      subject: "subjectVal"
-    };
 
     secretUtils.getSecretConfigs.mockImplementationOnce(() => Promise.resolve(configs));
-    utils.getAccessToken.mockImplementationOnce(() =>
-      Promise.resolve("test1234")
-    );
-    axiosWrapper.apiEndpoint.mockImplementationOnce(() =>
-      Promise.reject(error)
-    );
+    utils.getAccessToken.mockImplementationOnce(() => Promise.resolve("test1234"));
+    axiosWrapper.apiEndpoint.mockImplementationOnce(() => Promise.reject(error));
 
     const errorResponse = {
       success: false,


### PR DESCRIPTION
## Problem

Closes #108

`updateRecord` in `invokeSfRestApi/sfRestApi.js` incorrectly returns `{ success: false }` when a Salesforce PATCH request succeeds.

Salesforce REST API returns **HTTP 204 No Content** on a successful PATCH. The previous code tried to detect this by checking `response.data === ""`:

```javascript
// before
if (response.data === "") {
    return { success: true };
}
return { success: false };  // reached for null / undefined response.data
```

This is fragile: the axios Node.js HTTP adapter may return `null` or `undefined` (not `""`) for a 204 response body depending on version and runtime environment. When that happens, the strict `=== ""` check fails and the function returns `{ success: false }` even though the record was updated successfully.

## Fix

Since axios throws for non-2xx responses by default, any code path that reaches the `return` statement already represents a successful (2xx) response. The `response.data` check is unnecessary and has been removed:

```javascript
// after
// Salesforce returns 204 No Content on a successful PATCH.
// axios throws on non-2xx, so reaching here always means success.
return { success: true };
```

## Changes

| File | Change |
|---|---|
| `invokeSfRestApi/sfRestApi.js` | Remove fragile `response.data === ""` check in `updateRecord` |
| `invokeSfRestApi/tests/sfRestApi.test.js` | Add test cases for `data: null` and `data: undefined` (the previously broken scenarios); refactor shared `configs` to reduce duplication |

## Testing

Three test cases now cover the 204 No Content success path:

- `data: ""` — original case, still passes
- `data: null` — previously returned `{ success: false }`, now returns `{ success: true }`
- `data: undefined` — previously returned `{ success: false }`, now returns `{ success: true }`

The existing error path test (`404 Not Found`) is unchanged and continues to pass.