### PR TITLE
feat: add deleteRecord support to invokeSfRestApi

### DIFF
--- a/invokeSfRestApi/handler.js
+++ b/invokeSfRestApi/handler.js
@@ -58,6 +58,14 @@ exports.handler = async (event) => {
         accessTokenSecretName
       );
       break;
+    case "deleteRecord":
+      result = await api.deleteRecord(
+        utils.formatObjectApiName(objectApiName),
+        recordId,
+        secretName,
+        accessTokenSecretName
+      );
+      break;
     case "queryRecord": {
       result = dispatchQuery(soql, event, secretName, accessTokenSecretName);
       break;

--- a/invokeSfRestApi/sfRestApi.js
+++ b/invokeSfRestApi/sfRestApi.js
@@ -108,6 +108,27 @@ async function updateRecord(objectApiName, recordId, fieldValues, secretName, ac
   }
 }
 
+async function deleteRecord(objectApiName, recordId, secretName, accessTokenSecretName) {
+  try {
+    await sendRequest(
+      secretName,
+      accessTokenSecretName,
+      "delete",
+      `/sobjects/${objectApiName}/${recordId}`,
+    );
+    SCVLoggingUtil.debug({
+      category: "sfRestApi.deleteRecord",
+      message: "delete Record response",
+      context: { objectApiName, recordId },
+    });
+    // Salesforce returns 204 No Content on a successful DELETE.
+    // axios throws on non-2xx, so reaching here always means success.
+    return { success: true };
+  } catch (e) {
+    return buildError(e);
+  }
+}
+
 async function sendRealtimeAlertEvent(fieldValues, secretName, accessTokenSecretName) {
   try {
     const response = await sendRequest(
@@ -246,6 +267,7 @@ async function searchRecord(sosl, secretName, accessTokenSecretName) {
 module.exports = {
   createRecord,
   updateRecord,
+  deleteRecord,
   queryRecord,
   searchRecord,
   sendRealtimeAlertEvent,

--- a/invokeSfRestApi/tests/sfRestApi.test.js
+++ b/invokeSfRestApi/tests/sfRestApi.test.js
@@ -173,6 +173,68 @@ describe("updateRecord", () => {
   });
 });
 
+describe("deleteRecord", () => {
+  const configs = {
+    callCenterApiName: "callCenterApiNameVal",
+    baseURL: "baseURLVal",
+    authEndpoint: "authEndpointVal",
+    consumerKey: "consumerKeyVal",
+    privateKey: "privateKeyVal",
+    audience: "audienceVal",
+    subject: "subjectVal"
+  };
+
+  it("deletes a record successfully using the api (204 No Content)", async () => {
+    secretUtils.getSecretConfigs.mockImplementationOnce(() => Promise.resolve(configs));
+    utils.getAccessToken.mockImplementationOnce(() => Promise.resolve("test1234"));
+    axiosWrapper.apiEndpoint.mockImplementationOnce(() =>
+      Promise.resolve({ data: "" })
+    );
+
+    await expect(
+      await api.deleteRecord("Account", "1234", "secretName", "accessTokenSecretName")
+    ).toEqual({ success: true });
+
+    expect(axiosWrapper.apiEndpoint).toHaveBeenCalledWith({
+      data: undefined,
+      baseURL: "baseURLVal",
+      headers: { Authorization: "Bearer test1234" },
+      method: "delete",
+      url: "/sobjects/Account/1234",
+    });
+  });
+
+  it("returns an error response when the record is not found", async () => {
+    const error = {
+      response: {
+        success: false,
+        status: 404,
+        statusText: "not found",
+        data: [
+          {
+            message: "The requested resource does not exist",
+            errorCode: "NOT_FOUND",
+          },
+        ],
+      },
+    };
+
+    secretUtils.getSecretConfigs.mockImplementationOnce(() => Promise.resolve(configs));
+    utils.getAccessToken.mockImplementationOnce(() => Promise.resolve("test1234"));
+    axiosWrapper.apiEndpoint.mockImplementationOnce(() => Promise.reject(error));
+
+    await expect(
+      await api.deleteRecord("Account", "nonexistent", "secretName", "accessTokenSecretName")
+    ).toEqual({
+      success: false,
+      status: 404,
+      statusText: "not found",
+      errorMessage: "The requested resource does not exist",
+      errorCode: "NOT_FOUND",
+    });
+  });
+});
+
 describe("queryRecord", () => {
   it("queries a record sucessfully using the api", async () => {
     const data = {


### PR DESCRIPTION
## Summary

Closes #110

Adds `deleteRecord` to `invokeSfRestApi`, implementing the missing `DELETE /sobjects/{ObjectApiName}/{recordId}` operation. Previously, passing `methodName: "deleteRecord"` from an Amazon Connect contact flow would hit the `default` branch and throw `Unsupported method: deleteRecord`.

## Changes

| File | Change |
|---|---|
| `invokeSfRestApi/sfRestApi.js` | Add `deleteRecord` function; export it |
| `invokeSfRestApi/handler.js` | Add `case "deleteRecord":` to the `methodName` switch |
| `invokeSfRestApi/tests/sfRestApi.test.js` | Add `deleteRecord` describe block with success and 404-error test cases |

## Implementation notes

- Follows the same pattern as `updateRecord` — Salesforce returns **204 No Content** on success, axios throws on non-2xx
- No request body is sent (standard REST DELETE)
- The debug log records `objectApiName` and `recordId` since there is no response body to log
- `handler.js` passes `objectApiName` through `utils.formatObjectApiName` and `recordId` directly, consistent with `updateRecord`

## Usage (from a contact flow Invoke AWS Lambda block)

```json
{
  "methodName": "deleteRecord",
  "objectApiName": "Account",
  "recordId": "001Dn00000XXXXXXIAX"
}
```

On success: `{ "success": true }`  
On failure: `{ "success": false, "status": 404, "errorCode": "NOT_FOUND", "errorMessage": "..." }`