### PR TITLE
Release: CC22.0

### DIFF
--- a/cloudformation/BYOAContactCenterStack.yaml
+++ b/cloudformation/BYOAContactCenterStack.yaml
@@ -101,9 +101,6 @@ Outputs:
   InvokeTelephonyIntegrationApiFunction:
     Description: InvokeTelephonyIntegrationApi Lambda Function ARN
     Value: !GetAtt InvokeTelephonyIntegrationApiFunction.Arn
-  InvokeVfsIntegrationApiFunction:
-    Description: InvokeVfsIntegrationApi Lambda Function ARN
-    Value: !GetAtt InvokeVfsIntegrationApiFunction.Arn
   kvsTranscriber:
     Description: kvsTranscriber Lambda Function ARN
     Value: !GetAtt kvsTranscriber.Arn
@@ -220,16 +217,6 @@ Resources:
         S3Key: !Sub '${SalesforceRelease}/invokeTelephonyIntegrationApiFunctionLayer${Version}'
       Description: InvokeTelephonyIntegrationApiFunction node modules
       LayerName: InvokeTelephonyIntegrationApiFunctionLayer
-  InvokeVfsIntegrationApiFunctionLayer:
-    Type: 'AWS::Lambda::LayerVersion'
-    Properties:
-      CompatibleRuntimes:
-        - nodejs22.x
-      Content:
-        S3Bucket: !Sub '${S3BucketForScvResources}-${AWS::Region}'
-        S3Key: !Sub '${SalesforceRelease}/invokeVfsIntegrationApiFunctionLayer${Version}'
-      Description: InvokeVfsIntegrationApiFunction node modules
-      LayerName: InvokeVfsIntegrationApiFunctionLayer
   KVSConsumerTriggerFunctionLayer:
     Type: 'AWS::Lambda::LayerVersion'
     Properties:
@@ -368,26 +355,6 @@ Resources:
       Layers:
         - Ref: InvokeTelephonyIntegrationApiFunctionLayer
       Description: Creates VoiceCall records and handles OmniChannel routing
-  InvokeVfsIntegrationApiFunction:
-    Type: AWS::Serverless::Function
-    Properties:
-      CodeUri:
-        Bucket: !Sub "${S3BucketForScvResources}-${AWS::Region}"
-        Key: !Sub "${SalesforceRelease}/invokeVfsIntegrationApi${Version}"
-      Environment:
-        Variables:
-          LOG_LEVEL: "info"
-          SECRET_NAME: !Sub "${CallCenterApiName}-salesforce-secret"
-      Handler: handler.handler
-      AutoPublishAlias: active
-      VersionDescription: !Sub "Service Cloud Voice Lambda Version ${Version}"
-      Role: !Sub "arn:${AWS::Partition}:iam::${AWS::AccountId}:role/SCVInvokeVfsIntegrationApiFunctionRole"
-      Timeout: 8
-      Runtime: nodejs22.x
-      FunctionName: !If [LambdaPrefixIsNull, !Sub "${CallCenterApiName}-InvokeVfsIntegrationApiFunction", !Sub "${LambdaPrefix}-InvokeVfsIntegrationApiFunction"]
-      Layers:
-        - Ref: InvokeVfsIntegrationApiFunctionLayer
-      Description: Retrieves voicemail recording URLs
   InvokeSalesforceRestApiFunction:
     Type: AWS::Serverless::Function
     Properties:
@@ -526,15 +493,6 @@ Resources:
     Type: AWS::Lambda::Permission
     Properties:
       FunctionName: !Ref InvokeTelephonyIntegrationApiFunction.Alias
-      Action: lambda:InvokeFunction
-      Principal: connect.amazonaws.com
-      SourceAccount: !Sub ${AWS::AccountId}
-      SourceArn: !Sub "arn:${AWS::Partition}:connect:${AWS::Region}:${AWS::AccountId}:instance/${ConnectInstanceId}"
-
-  InvokeVfsIntegrationApiFunctionPermission:  
-    Type: AWS::Lambda::Permission
-    Properties:
-      FunctionName: !Ref InvokeVfsIntegrationApiFunction.Alias
       Action: lambda:InvokeFunction
       Principal: connect.amazonaws.com
       SourceAccount: !Sub ${AWS::AccountId}
@@ -984,7 +942,6 @@ Resources:
     DependsOn:
       - HandleContactEventsFunction
       - InvokeTelephonyIntegrationApiFunction
-      - InvokeVfsIntegrationApiFunction
       - ContactLensConsumerFunction
       - kvsConsumerTrigger
       - CTRDataSyncFunction
@@ -1001,7 +958,6 @@ Resources:
         S3BucketForScvResources: !Sub "${S3BucketForScvResources}"
         RealtimeAlertRole: !Sub "arn:${AWS::Partition}:iam::${AWS::AccountId}:role/SCVRealtimeAlertRole"
         InvokeTelephonyIntegrationApiFunctionName: !Ref InvokeTelephonyIntegrationApiFunction
-        InvokeVfsIntegrationApiFunctionName: !Ref InvokeVfsIntegrationApiFunction
         InvokeSalesforceRestApiFunctionName: !Ref InvokeSalesforceRestApiFunction
         CTRDataSyncFunctionName: !Ref CTRDataSyncFunction
         ContactDataSyncFunctionName: !Ref ContactDataSyncFunction
@@ -1048,7 +1004,6 @@ Resources:
       - S3Bucket
       - LiveMediaStreamKmsKey
       - InvokeTelephonyIntegrationApiFunction
-      - InvokeVfsIntegrationApiFunction
       - ContactLensConsumerFunction
       - kvsConsumerTrigger
       - InvokeSalesforceRestApiFunction
@@ -1065,7 +1020,6 @@ Resources:
         ConnectConfiguratorLambdaRole: "SCVConnectConfiguratorLambdaRole"
         KinesisStreamArnForCTR: !GetAtt CTRStream.Arn
         InvokeTelephonyApiLambdaArn: !GetAtt InvokeTelephonyIntegrationApiFunction.Arn
-        InvokeVfsApiLambdaArn: !GetAtt InvokeVfsIntegrationApiFunction.Arn
         ContactLensConsumerLambdaArn: !GetAtt ContactLensConsumerFunction.Arn
         KvsConsumerTriggerLambdaArn: !GetAtt kvsConsumerTrigger.Arn
         KinesisStreamArnForContactLens: !GetAtt ContactLensStream.Arn

--- a/cloudformation/BYOAHealthCheckStack.yaml
+++ b/cloudformation/BYOAHealthCheckStack.yaml
@@ -166,8 +166,6 @@ Resources:
               - !Sub "arn:${AWS::Partition}:lambda:*:${AWS::AccountId}:function:${LambdaPrefix}-MultiorgInvokeSalesforceRestApiFunction:*"
               - !Sub "arn:${AWS::Partition}:lambda:*:${AWS::AccountId}:function:${LambdaPrefix}-MultiorgInvokeTelephonyIntegrationApiFunction"
               - !Sub "arn:${AWS::Partition}:lambda:*:${AWS::AccountId}:function:${LambdaPrefix}-MultiorgInvokeTelephonyIntegrationApiFunction:*"
-              - !Sub "arn:${AWS::Partition}:lambda:*:${AWS::AccountId}:function:${LambdaPrefix}-MultiorgInvokeVfsIntegrationApiFunction"
-              - !Sub "arn:${AWS::Partition}:lambda:*:${AWS::AccountId}:function:${LambdaPrefix}-MultiorgInvokeVfsIntegrationApiFunction:*"
               - !Sub "arn:${AWS::Partition}:lambda:*:${AWS::AccountId}:function:${LambdaPrefix}-MultiorgKvsConsumerTrigger"
               - !Sub "arn:${AWS::Partition}:lambda:*:${AWS::AccountId}:function:${LambdaPrefix}-MultiorgKvsConsumerTrigger:*"
               - !Sub "arn:${AWS::Partition}:lambda:*:${AWS::AccountId}:function:${LambdaPrefix}-MultiorgPostCallAnalysisTrigger"
@@ -262,7 +260,6 @@ Resources:
                   - !Sub "arn:${AWS::Partition}:iam::${AWS::AccountId}:role/*PostCallAnalysisTriggerFunctionRole"
                   - !Sub "arn:${AWS::Partition}:iam::${AWS::AccountId}:role/*InvokeTelephonyIntegrationApiFunctionRole"
                   - !Sub "arn:${AWS::Partition}:iam::${AWS::AccountId}:role/*InvokeSalesforceRestApiFunctionRole"
-                  - !Sub "arn:${AWS::Partition}:iam::${AWS::AccountId}:role/*InvokeVfsIntegrationApiFunctionRole"
                   - !Sub "arn:${AWS::Partition}:iam::${AWS::AccountId}:role/*SSMLambdaExecutionRole"
                   - !Sub "arn:${AWS::Partition}:iam::${AWS::AccountId}:role/*SecretConfiguratorLambdaRole"
                   - !Sub "arn:${AWS::Partition}:iam::${AWS::AccountId}:role/*KvsTranscriberRoleResource"
@@ -299,8 +296,6 @@ Resources:
                   - !If [HasLambdaPrefix, !Sub "arn:${AWS::Partition}:lambda:*:${AWS::AccountId}:function:${LambdaPrefix}-InvokeTelephonyIntegrationApiFunction:*", !Sub "arn:${AWS::Partition}:lambda:*:${AWS::AccountId}:function:${CallCenterApiName}-InvokeTelephonyIntegrationApiFunction:*"]
                   - !If [HasLambdaPrefix, !Sub "arn:${AWS::Partition}:lambda:*:${AWS::AccountId}:function:${LambdaPrefix}-InvokeSalesforceRestApiFunction", !Sub "arn:${AWS::Partition}:lambda:*:${AWS::AccountId}:function:${CallCenterApiName}-InvokeSalesforceRestApiFunction"]
                   - !If [HasLambdaPrefix, !Sub "arn:${AWS::Partition}:lambda:*:${AWS::AccountId}:function:${LambdaPrefix}-InvokeSalesforceRestApiFunction:*", !Sub "arn:${AWS::Partition}:lambda:*:${AWS::AccountId}:function:${CallCenterApiName}-InvokeSalesforceRestApiFunction:*"]
-                  - !If [HasLambdaPrefix, !Sub "arn:${AWS::Partition}:lambda:*:${AWS::AccountId}:function:${LambdaPrefix}-InvokeVfsIntegrationApiFunction", !Sub "arn:${AWS::Partition}:lambda:*:${AWS::AccountId}:function:${CallCenterApiName}-InvokeVfsIntegrationApiFunction"]
-                  - !If [HasLambdaPrefix, !Sub "arn:${AWS::Partition}:lambda:*:${AWS::AccountId}:function:${LambdaPrefix}-InvokeVfsIntegrationApiFunction:*", !Sub "arn:${AWS::Partition}:lambda:*:${AWS::AccountId}:function:${CallCenterApiName}-InvokeVfsIntegrationApiFunction:*"]
                   - !If [HasLambdaPrefix, !Sub "arn:${AWS::Partition}:lambda:*:${AWS::AccountId}:function:${LambdaPrefix}-kvsTranscriber", !Sub "arn:${AWS::Partition}:lambda:*:${AWS::AccountId}:function:${CallCenterApiName}-kvsTranscriber"]
                   - !If [HasLambdaPrefix, !Sub "arn:${AWS::Partition}:lambda:*:${AWS::AccountId}:function:${LambdaPrefix}-kvsTranscriber:*", !Sub "arn:${AWS::Partition}:lambda:*:${AWS::AccountId}:function:${CallCenterApiName}-kvsTranscriber:*"]
                   - !If [HasLambdaPrefix, !Sub "arn:${AWS::Partition}:lambda:*:${AWS::AccountId}:function:${LambdaPrefix}-kvsConsumerTrigger", !Sub "arn:${AWS::Partition}:lambda:*:${AWS::AccountId}:function:${CallCenterApiName}-kvsConsumerTrigger"]

--- a/cloudformation/BYOATenantStack.yaml
+++ b/cloudformation/BYOATenantStack.yaml
@@ -167,30 +167,6 @@ Resources:
         - Outputs.SecretsManagerManagedPolicyResource
       RoleName: "SCVInvokeTelephonyIntegrationApiFunctionRole"
       Description: InvokeTelephonyIntegrationApiFunction Lambda function assumes this role to create Service cloud voice calls to invoke CreateVoiceCall API explained here https://developer.salesforce.com/docs/atlas.en-us.voice_developer_guide.meta/voice_developer_guide/voice_rest_voicecalls_create.htm
-  SCVInvokeVfsIntegrationApiFunctionRoleResource:
-    Type: AWS::IAM::Role
-    Properties:
-      PermissionsBoundary:
-       !If [PermissionBoundaryIsNull, !Ref "AWS::NoValue", !Ref PermissionBoundaryARN]
-      AssumeRolePolicyDocument:
-        Version: '2012-10-17'
-        Statement:
-        - Action:
-          - sts:AssumeRole
-          Effect: Allow
-          Principal:
-            Service:
-            - lambda.amazonaws.com
-      ManagedPolicyArns:
-      - !Sub "arn:${AWS::Partition}:iam::aws:policy/service-role/AWSLambdaBasicExecutionRole"
-      - !GetAtt
-        - SCVManagedPolicyStack
-        - Outputs.SSMManagedPolicyResource
-      - !GetAtt
-        - SCVManagedPolicyStack
-        - Outputs.SecretsManagerManagedPolicyResource
-      RoleName: "SCVInvokeVfsIntegrationApiFunctionRole"
-      Description: InvokeVfsIntegrationApiFunction Lambda function assumes this role to invoke VFS API calls such as retrieving voicemail drop recordings.
   SCVInvokeSalesforceRestApiFunctionRoleResource:
     Type: AWS::IAM::Role
     Properties:
@@ -887,9 +863,6 @@ Outputs:
   SCVInvokeTelephonyIntegrationApiFunctionRoleResource:
     Description: Implicit IAM Role created for InvokeTelephonyIntegrationApiFunction
     Value: !GetAtt SCVInvokeTelephonyIntegrationApiFunctionRoleResource.Arn
-  SCVInvokeVfsIntegrationApiFunctionRoleResource:
-    Description: Implicit IAM Role created for InvokeVfsIntegrationApiFunction
-    Value: !GetAtt SCVInvokeVfsIntegrationApiFunctionRoleResource.Arn
   SCVPostCallAnalysisTriggerFunctionRoleResource:
     Description: Implicit IAM Role created for PostCallAnalysisTriggerFunction
     Value: !GetAtt SCVPostCallAnalysisTriggerFunctionRoleResource.Arn

--- a/cloudformation/ConnectConfigurationStack.yaml
+++ b/cloudformation/ConnectConfigurationStack.yaml
@@ -33,9 +33,6 @@ Parameters:
   InvokeTelephonyApiLambdaArn:
     Type: String
     Description: Invoke Telephony API Lambda Arn
-  InvokeVfsApiLambdaArn:
-    Type: String
-    Description: Invoke VFS API Lambda Arn
   ContactLensConsumerLambdaArn:
     Type: String
     Description: ContactLensConsumer Lambda Arn
@@ -200,13 +197,6 @@ Resources:
     Properties:
       InstanceId: !Sub "arn:${AWS::Partition}:connect:${AWS::Region}:${AWS::AccountId}:instance/${ConnectInstanceId}"
       IntegrationArn: !Sub "${InvokeTelephonyApiLambdaArn}:active"
-      IntegrationType: "LAMBDA_FUNCTION"
-  InvokeVfsLambdaAssociationResource:
-    Type: AWS::Connect::IntegrationAssociation
-    DependsOn: InvokeTelephonyLambdaAssociationResource
-    Properties:
-      InstanceId: !Sub "arn:${AWS::Partition}:connect:${AWS::Region}:${AWS::AccountId}:instance/${ConnectInstanceId}"
-      IntegrationArn: !Sub "${InvokeVfsApiLambdaArn}:active"
       IntegrationType: "LAMBDA_FUNCTION"
   KvsConsumerTriggerAssociationResource:
     Type: AWS::Connect::IntegrationAssociation

--- a/cloudformation/MultiorgProvisioningServiceStack.yaml
+++ b/cloudformation/MultiorgProvisioningServiceStack.yaml
@@ -86,29 +86,7 @@ Resources:
         - !Ref LambdaS3AccessPolicyResource
       RoleName: !Sub "${lambdaPrefix}-InvokeTelephonyIntegrationApiFunctionRole"
       Description: Creates VoiceCall records via Salesforce Telephony API
-  
-  MultiorgInvokeVfsIntegrationApiFunctionRoleResource:
-    Type: AWS::IAM::Role
-    Properties:
-      PermissionsBoundary:
-        !If [PermissionBoundaryIsNull, !Ref "AWS::NoValue", !Ref PermissionBoundaryARN]
-      AssumeRolePolicyDocument:
-        Version: '2012-10-17'
-        Statement:
-          - Action:
-              - sts:AssumeRole
-            Effect: Allow
-            Principal:
-              Service:
-                - lambda.amazonaws.com
-      ManagedPolicyArns:
-        - !Sub "arn:${AWS::Partition}:iam::aws:policy/service-role/AWSLambdaBasicExecutionRole"
-        - !Sub "arn:aws:iam::${AWS::AccountId}:policy/scv/SCVSSMAccessPolicy"
-        - !Sub "arn:aws:iam::${AWS::AccountId}:policy/scv/SCVSecretsManagerAccessPolicy"
-        - !Ref LambdaS3AccessPolicyResource
-      RoleName: !Sub "${lambdaPrefix}-InvokeVfsIntegrationApiFunctionRole"
-      Description: Retrieves voicemail recording URLs via VFS API
-  
+
   MultiorgContactDataSyncFunctionRoleResource:
     Type: AWS::IAM::Role
     Properties:
@@ -496,17 +474,6 @@ Resources:
       Description: MultiorgInvokeTelephonyIntegrationApiFunction node modules
       LayerName: !Sub '${lambdaPrefix}-MultiorgInvokeTelephonyIntegrationApiFunctionLayer'
 
-  MultiorgInvokeVfsIntegrationApiFunctionLayer:
-    Type: 'AWS::Lambda::LayerVersion'
-    Properties:
-      CompatibleRuntimes:
-        - nodejs22.x
-      Content:
-        S3Bucket:  !Sub '${S3BucketForScvResources}-${AWS::Region}'
-        S3Key: !Sub '${SalesforceRelease}/invokeVfsIntegrationApiFunctionLayer${Version}'
-      Description: MultiorgInvokeVfsIntegrationApiFunction node modules
-      LayerName: !Sub '${lambdaPrefix}-MultiorgInvokeVfsIntegrationApiFunctionLayer'
-
   MultiorgHandleContactEventsFunctionLayer:
     Type: AWS::Lambda::LayerVersion
     Properties:
@@ -659,27 +626,6 @@ Resources:
         - !Ref MultiorgInvokeTelephonyIntegrationApiFunctionLayer
       Description: Creates VoiceCall records and handles OmniChannel routing
 
-  MultiorgInvokeVfsIntegrationApiFunction:
-    Type: AWS::Serverless::Function
-    Properties:
-      CodeUri:
-        Bucket: !Sub "${S3BucketForScvResources}-${AWS::Region}"
-        Key: !Sub "${SalesforceRelease}/invokeVfsIntegrationApi${Version}"
-      Environment:
-        Variables:
-          LOG_LEVEL: "info"
-          SECRET_CACHE_S3: !Sub "${S3BucketForTenantResources}/secret_cache"
-      Handler: handler.handler
-      AutoPublishAlias: active
-      VersionDescription: !Sub "Service Cloud Voice Lambda Version ${Version}"
-      Role: !GetAtt MultiorgInvokeVfsIntegrationApiFunctionRoleResource.Arn
-      Timeout: 8
-      Runtime: nodejs22.x
-      FunctionName: !Sub "${lambdaPrefix}-MultiorgInvokeVfsIntegrationApiFunction"
-      Layers:
-        - !Ref MultiorgInvokeVfsIntegrationApiFunctionLayer
-      Description: Retrieves voicemail recording URLs
-      
   MultiorgHandleContactEventsFunction:
     Type: AWS::Serverless::Function
     Properties:
@@ -895,7 +841,6 @@ Resources:
     DependsOn:
       - MultiorgInvokeSalesforceRestApiFunction
       - MultiorgInvokeTelephonyIntegrationApiFunction
-      - MultiorgInvokeVfsIntegrationApiFunction
       - MultiorgCTRDataSyncFunction
       - MultiorgContactDataSyncFunction
       - MultiorgKvsConsumerTrigger
@@ -912,7 +857,6 @@ Resources:
         S3BucketForScvResources: !Ref S3BucketForScvResources
         RealtimeAlertRole: !Sub "arn:${AWS::Partition}:iam::${AWS::AccountId}:role/SCVRealtimeAlertRole"
         InvokeTelephonyIntegrationApiFunctionName: !Sub "${lambdaPrefix}-MultiorgInvokeTelephonyIntegrationApiFunction"
-        InvokeVfsIntegrationApiFunctionName: !Sub "${lambdaPrefix}-MultiorgInvokeVfsIntegrationApiFunction"
         InvokeSalesforceRestApiFunctionName: !Sub "${lambdaPrefix}-MultiorgInvokeSalesforceRestApiFunction"
         CTRDataSyncFunctionName: !Sub "${lambdaPrefix}-MultiorgCTRDataSyncFunction"
         ContactDataSyncFunctionName: !Sub "${lambdaPrefix}-MultiorgContactDataSync"
@@ -1042,13 +986,6 @@ Resources:
     Properties:
       InstanceId: !Sub "arn:${AWS::Partition}:connect:${AWS::Region}:${AWS::AccountId}:instance/${ConnectInstanceId}"
       IntegrationArn: !GetAtt MultiorgInvokeTelephonyIntegrationApiFunction.Arn
-      IntegrationType: LAMBDA_FUNCTION
-
-  MultiorgInvokeVfsIntegrationApiIntegrationAssociationResource:
-    Type: AWS::Connect::IntegrationAssociation
-    Properties:
-      InstanceId: !Sub "arn:${AWS::Partition}:connect:${AWS::Region}:${AWS::AccountId}:instance/${ConnectInstanceId}"
-      IntegrationArn: !GetAtt MultiorgInvokeVfsIntegrationApiFunction.Arn
       IntegrationType: LAMBDA_FUNCTION
 
   MultiorgKvsConsumerTriggerIntegrationAssociationResource:

--- a/cloudformation/RealtimeAlertStack.yaml
+++ b/cloudformation/RealtimeAlertStack.yaml
@@ -30,9 +30,6 @@ Parameters:
   InvokeTelephonyIntegrationApiFunctionName:
     Description: InvokeTelephonyIntegrationApi Lambda Function Name.
     Type: String
-  InvokeVfsIntegrationApiFunctionName:
-    Description: InvokeVfsIntegrationApi Lambda Function Name.
-    Type: String
   InvokeSalesforceRestApiFunctionName:
     Description: InvokeSalesforceRestApiFunctionName Lambda Function Name.
     Type: String
@@ -319,50 +316,6 @@ Resources:
       Dimensions:
         - Name: FunctionName
           Value: !Ref InvokeTelephonyIntegrationApiFunctionName
-      ComparisonOperator: GreaterThanOrEqualToThreshold
-      TreatMissingData: "notBreaching"
-
-  InvokeVfsIntegrationApiFunctionErrorsAlarm:
-    Type: AWS::CloudWatch::Alarm
-    Properties:
-      AlarmName: !Sub "SCV Lambda ${InvokeVfsIntegrationApiFunctionName} Errors"
-      AlarmDescription: !Sub "The number of invocations of ${InvokeVfsIntegrationApiFunctionName} that resulted in a function error. Function errors include exceptions thrown by your code and exceptions thrown by the Lambda runtime."
-      Namespace: AWS/Lambda
-      MetricName: Errors
-      Statistic: Sum
-      Unit: Count
-      AlarmActions: !If
-        - CreateEventTriggers
-        - - !Ref RealtimeAlertAlarmSnsTopic
-        - !Ref AWS::NoValue
-      Period: 60
-      Threshold: 3
-      EvaluationPeriods: 1
-      Dimensions:
-        - Name: FunctionName
-          Value: !Ref InvokeVfsIntegrationApiFunctionName
-      ComparisonOperator: GreaterThanOrEqualToThreshold
-      TreatMissingData: "notBreaching"
-  InvokeVfsIntegrationApiFunctionThrottlesAlarm:
-    Type: AWS::CloudWatch::Alarm
-    Properties:
-      ActionsEnabled: false
-      AlarmName: !Sub "SCV Lambda ${InvokeVfsIntegrationApiFunctionName} Throttles"
-      AlarmDescription: !Sub "The number of invocation requests of ${InvokeVfsIntegrationApiFunctionName} that are throttled. Review concurrent executions quota for the region, or the reserved concurrency limit that you configured on the function."
-      Namespace: AWS/Lambda
-      MetricName: Throttles
-      Statistic: Sum
-      Unit: Count
-      AlarmActions: !If
-        - CreateEventTriggers
-        - - !Ref RealtimeAlertAlarmSnsTopic
-        - !Ref AWS::NoValue
-      Period: 60
-      Threshold: 5
-      EvaluationPeriods: 1
-      Dimensions:
-        - Name: FunctionName
-          Value: !Ref InvokeVfsIntegrationApiFunctionName
       ComparisonOperator: GreaterThanOrEqualToThreshold
       TreatMissingData: "notBreaching"
 
@@ -726,7 +679,7 @@ Resources:
   ServiceCloudVoiceLambdaDashboard:
     Type: "AWS::CloudWatch::Dashboard"
     Properties:
-      DashboardBody: !Sub '{"widgets": [{"type": "metric","x": 0,"y": 0,"width": 6,"height": 6,"properties": {"metrics": [["AWS/Lambda","Errors","FunctionName","${InvokeSalesforceRestApiFunctionName}"],[".","ConcurrentExecutions",".","."],[".","Invocations",".","."],[".","Throttles",".","."]],"view": "timeSeries","stacked": true,"region": "${AWS::Region}","stat": "Sum","period": 300,"title": "${InvokeSalesforceRestApiFunctionName}"}},{"type": "metric","x": 6,"y": 0,"width": 6,"height": 6,"properties": {"metrics": [["AWS/Lambda","Errors","FunctionName","${InvokeTelephonyIntegrationApiFunctionName}"],[".","ConcurrentExecutions",".","."],[".","Invocations",".","."],[".","Throttles",".","."]],"view": "timeSeries","stacked": true,"region": "${AWS::Region}","stat": "Sum","period": 300,"title": "${InvokeTelephonyIntegrationApiFunctionName}"}},{"type": "metric","x": 12,"y": 0,"width": 6,"height": 6,"properties": {"metrics": [["AWS/Lambda","Errors","FunctionName","${CTRDataSyncFunctionName}"],[".","ConcurrentExecutions",".","."],[".","Invocations",".","."],[".","Throttles",".","."]],"view": "timeSeries","stacked": true,"region": "${AWS::Region}","stat": "Sum","period": 300,"title": "${CTRDataSyncFunctionName}"}},{"type": "metric","x": 0,"y": 6,"width": 6,"height": 6,"properties": {"metrics": [["AWS/Lambda","Errors","FunctionName","${kvsTranscriberName}"],[".","ConcurrentExecutions",".","."],[".","Invocations",".","."],[".","Throttles",".","."]],"view": "timeSeries","stacked": true,"region": "${AWS::Region}","stat": "Sum","period": 300,"title": "${kvsTranscriberName}"}},{"type": "metric","x": 6,"y": 6,"width": 6,"height": 6,"properties": {"metrics": [["AWS/Lambda","Errors","FunctionName","${kvsConsumerTriggerName}"],[".","ConcurrentExecutions",".","."],[".","Invocations",".","."],[".","Throttles",".","."]],"view": "timeSeries","stacked": true,"region": "${AWS::Region}","stat": "Sum","period": 300,"title": "${kvsConsumerTriggerName}"}},{"type": "metric","x": 12,"y": 6,"width": 6,"height": 6,"properties": {"metrics": [["AWS/Lambda","Errors","FunctionName","${HandleContactEventsFunctionName}"],[".","ConcurrentExecutions",".","."],[".","Invocations",".","."],[".","Throttles",".","."]],"view": "timeSeries","stacked": true,"region": "${AWS::Region}","stat": "Sum","period": 300,"title": "${HandleContactEventsFunctionName}"}},{"type": "metric","x": 0,"y": 12,"width": 6,"height": 6,"properties": {"metrics": [["AWS/Lambda","Errors","FunctionName","${ContactLensConsumerFunctionName}"],[".","ConcurrentExecutions",".","."],[".","Invocations",".","."],[".","Throttles",".","."]],"view": "timeSeries","stacked": true,"region": "${AWS::Region}","stat": "Sum","period": 300,"title": "${ContactLensConsumerFunctionName}"}},{"type": "metric","x": 6,"y": 12,"width": 6,"height": 6,"properties": {"metrics": [["AWS/Lambda","Errors","FunctionName","${VoiceMailAudioProcessingFunctionName}"],[".","ConcurrentExecutions",".","."],[".","Invocations",".","."],[".","Throttles",".","."]],"view": "timeSeries","stacked": true,"region": "${AWS::Region}","stat": "Sum","period": 300,"title": "${VoiceMailAudioProcessingFunctionName}"}},{"type": "metric","x": 12,"y": 12,"width": 6,"height": 6,"properties": {"metrics": [["AWS/Lambda","Errors","FunctionName","${VoiceMailPackagingFunctionName}"],[".","ConcurrentExecutions",".","."],[".","Invocations",".","."],[".","Throttles",".","."]],"view": "timeSeries","stacked": true,"region": "${AWS::Region}","stat": "Sum","period": 300,"title": "${VoiceMailPackagingFunctionName}"}},{"type": "metric","x": 0,"y": 24,"width": 6,"height": 6,"properties": {"metrics": [["AWS/Lambda","Errors","FunctionName","${VoiceMailTranscribeFunctionName}"],[".","ConcurrentExecutions",".","."],[".","Invocations",".","."],[".","Throttles",".","."]],"view": "timeSeries","stacked": true,"region": "${AWS::Region}","stat": "Sum","period": 300,"title": "${VoiceMailTranscribeFunctionName}"}}, {"type": "metric","x": 6,"y": 24,"width": 6,"height": 6,"properties": {"metrics": [["AWS/Lambda","Errors","FunctionName","${ContactDataSyncFunctionName}"],[".","ConcurrentExecutions",".","."],[".","Invocations",".","."],[".","Throttles",".","."]],"view": "timeSeries","stacked": true,"region": "${AWS::Region}","stat": "Sum","period": 300,"title": "${ContactDataSyncFunctionName}"}},{"type": "metric","x": 12,"y": 24,"width": 6,"height": 6,"properties": {"metrics": [["AWS/Lambda","Errors","FunctionName","${InvokeVfsIntegrationApiFunctionName}"],[".","ConcurrentExecutions",".","."],[".","Invocations",".","."],[".","Throttles",".","."]],"view": "timeSeries","stacked": true,"region": "${AWS::Region}","stat": "Sum","period": 300,"title": "${InvokeVfsIntegrationApiFunctionName}"}}]}'
+      DashboardBody: !Sub '{"widgets": [{"type": "metric","x": 0,"y": 0,"width": 6,"height": 6,"properties": {"metrics": [["AWS/Lambda","Errors","FunctionName","${InvokeSalesforceRestApiFunctionName}"],[".","ConcurrentExecutions",".","."],[".","Invocations",".","."],[".","Throttles",".","."]],"view": "timeSeries","stacked": true,"region": "${AWS::Region}","stat": "Sum","period": 300,"title": "${InvokeSalesforceRestApiFunctionName}"}},{"type": "metric","x": 6,"y": 0,"width": 6,"height": 6,"properties": {"metrics": [["AWS/Lambda","Errors","FunctionName","${InvokeTelephonyIntegrationApiFunctionName}"],[".","ConcurrentExecutions",".","."],[".","Invocations",".","."],[".","Throttles",".","."]],"view": "timeSeries","stacked": true,"region": "${AWS::Region}","stat": "Sum","period": 300,"title": "${InvokeTelephonyIntegrationApiFunctionName}"}},{"type": "metric","x": 12,"y": 0,"width": 6,"height": 6,"properties": {"metrics": [["AWS/Lambda","Errors","FunctionName","${CTRDataSyncFunctionName}"],[".","ConcurrentExecutions",".","."],[".","Invocations",".","."],[".","Throttles",".","."]],"view": "timeSeries","stacked": true,"region": "${AWS::Region}","stat": "Sum","period": 300,"title": "${CTRDataSyncFunctionName}"}},{"type": "metric","x": 0,"y": 6,"width": 6,"height": 6,"properties": {"metrics": [["AWS/Lambda","Errors","FunctionName","${kvsTranscriberName}"],[".","ConcurrentExecutions",".","."],[".","Invocations",".","."],[".","Throttles",".","."]],"view": "timeSeries","stacked": true,"region": "${AWS::Region}","stat": "Sum","period": 300,"title": "${kvsTranscriberName}"}},{"type": "metric","x": 6,"y": 6,"width": 6,"height": 6,"properties": {"metrics": [["AWS/Lambda","Errors","FunctionName","${kvsConsumerTriggerName}"],[".","ConcurrentExecutions",".","."],[".","Invocations",".","."],[".","Throttles",".","."]],"view": "timeSeries","stacked": true,"region": "${AWS::Region}","stat": "Sum","period": 300,"title": "${kvsConsumerTriggerName}"}},{"type": "metric","x": 12,"y": 6,"width": 6,"height": 6,"properties": {"metrics": [["AWS/Lambda","Errors","FunctionName","${HandleContactEventsFunctionName}"],[".","ConcurrentExecutions",".","."],[".","Invocations",".","."],[".","Throttles",".","."]],"view": "timeSeries","stacked": true,"region": "${AWS::Region}","stat": "Sum","period": 300,"title": "${HandleContactEventsFunctionName}"}},{"type": "metric","x": 0,"y": 12,"width": 6,"height": 6,"properties": {"metrics": [["AWS/Lambda","Errors","FunctionName","${ContactLensConsumerFunctionName}"],[".","ConcurrentExecutions",".","."],[".","Invocations",".","."],[".","Throttles",".","."]],"view": "timeSeries","stacked": true,"region": "${AWS::Region}","stat": "Sum","period": 300,"title": "${ContactLensConsumerFunctionName}"}},{"type": "metric","x": 6,"y": 12,"width": 6,"height": 6,"properties": {"metrics": [["AWS/Lambda","Errors","FunctionName","${VoiceMailAudioProcessingFunctionName}"],[".","ConcurrentExecutions",".","."],[".","Invocations",".","."],[".","Throttles",".","."]],"view": "timeSeries","stacked": true,"region": "${AWS::Region}","stat": "Sum","period": 300,"title": "${VoiceMailAudioProcessingFunctionName}"}},{"type": "metric","x": 12,"y": 12,"width": 6,"height": 6,"properties": {"metrics": [["AWS/Lambda","Errors","FunctionName","${VoiceMailPackagingFunctionName}"],[".","ConcurrentExecutions",".","."],[".","Invocations",".","."],[".","Throttles",".","."]],"view": "timeSeries","stacked": true,"region": "${AWS::Region}","stat": "Sum","period": 300,"title": "${VoiceMailPackagingFunctionName}"}},{"type": "metric","x": 0,"y": 24,"width": 6,"height": 6,"properties": {"metrics": [["AWS/Lambda","Errors","FunctionName","${VoiceMailTranscribeFunctionName}"],[".","ConcurrentExecutions",".","."],[".","Invocations",".","."],[".","Throttles",".","."]],"view": "timeSeries","stacked": true,"region": "${AWS::Region}","stat": "Sum","period": 300,"title": "${VoiceMailTranscribeFunctionName}"}}, {"type": "metric","x": 6,"y": 24,"width": 6,"height": 6,"properties": {"metrics": [["AWS/Lambda","Errors","FunctionName","${ContactDataSyncFunctionName}"],[".","ConcurrentExecutions",".","."],[".","Invocations",".","."],[".","Throttles",".","."]],"view": "timeSeries","stacked": true,"region": "${AWS::Region}","stat": "Sum","period": 300,"title": "${ContactDataSyncFunctionName}"}}]}'
       DashboardName: !If 
         - UseSourceCondition
         - !Sub '${CallCenterApiName}-ServiceCloudVoiceLambdaDashboard'

--- a/contactDataSync/package.json
+++ b/contactDataSync/package.json
@@ -10,8 +10,8 @@
   "dependencies": {
     "aws-sdk": "2.1354.0",
     "winston": "3.2.1",
-    "axios": "1.13.6",
-    "axios-logger": "2.5.0",
+    "axios": "1.18.1",
+    "axios-logger": "2.8.1",
     "jsonwebtoken": "9.0.3",
     "uuid": "3.4.0"
   },

--- a/contactLensConsumer/package.json
+++ b/contactLensConsumer/package.json
@@ -10,8 +10,8 @@
   "dependencies": {
     "aws-sdk": "2.1354.0",
     "winston": "3.2.1",
-    "axios": "1.13.6",
-    "axios-logger": "2.5.0",
+    "axios": "1.18.1",
+    "axios-logger": "2.8.1",
     "jsonwebtoken": "9.0.3",
     "uuid": "3.4.0"
   },

--- a/contactLensProcessor/handler.js
+++ b/contactLensProcessor/handler.js
@@ -12,8 +12,6 @@ exports.handler = async (event) => {
     context: { payload: event },
   });
 
-  const bulkSendMessagesPayload = {};
-  bulkSendMessagesPayload.entries = [];
   const contactIdToMessagesMap = {};
   const contactIdToSecretMap = {}
   if (event && event.Records) {
@@ -98,27 +96,30 @@ exports.handler = async (event) => {
     // Iterate through contactIdMessagesMap and construct the request payload for BulkSendMessages
     for(var secretName in secretNameToContactIdMap){
       var contactIds = secretNameToContactIdMap[secretName];
+      const bulkSendMessagesPayload = {};
+      bulkSendMessagesPayload.entries = [];
+      bulkSendMessagesPayload.secretName = secretName;
+
       // here we are making sure that we are first getting secretName and then grouping contactIds associated with that secretName.
       for (var key of contactIds) {
-      const bulkSendMessagePayload = {};
-      bulkSendMessagePayload.vendorCallKey = key;
-      bulkSendMessagePayload.messages = contactIdToMessagesMap[key];
+        const bulkSendMessagePayload = {};
+        bulkSendMessagePayload.vendorCallKey = key;
+        bulkSendMessagePayload.messages = contactIdToMessagesMap[key];
 
-      // Add to the bulkSendMessagesPayload.entries array
-      bulkSendMessagesPayload.secretName = secretName
-      bulkSendMessagesPayload.entries.push(bulkSendMessagePayload);
-    }
-    }
+        // Add to the bulkSendMessagesPayload.entries array
+        bulkSendMessagesPayload.entries.push(bulkSendMessagePayload);
+      }
 
-    SCVLoggingUtil.debug({
-      message:
-          "bulkSendMessagesPayload details",
-      context: { contactId: bulkSendMessagesPayload },
-    });
+      SCVLoggingUtil.debug({
+        message:
+            "bulkSendMessagesPayload details",
+        context: { contactId: bulkSendMessagesPayload },
+      });
 
-    //Call the BulkSendMessages API
-    if (bulkSendMessagesPayload.entries.length > 0) {
-      promises.push(api.sendMessagesInBulk(bulkSendMessagesPayload));
+      //Call the BulkSendMessages API
+      if (bulkSendMessagesPayload.entries.length > 0) {
+        promises.push(api.sendMessagesInBulk(bulkSendMessagesPayload));
+      }
     }
   }
 

--- a/contactLensProcessor/package.json
+++ b/contactLensProcessor/package.json
@@ -10,8 +10,8 @@
   "dependencies": {
     "aws-sdk": "2.1354.0",
     "winston": "3.2.1",
-    "axios": "1.13.6",
-    "axios-logger": "2.5.0",
+    "axios": "1.18.1",
+    "axios-logger": "2.8.1",
     "axios-retry": "3.3.1",
     "jsonwebtoken": "9.0.3",
     "uuid": "3.4.0"

--- a/ctrDataSync/tests/handler.test.js
+++ b/ctrDataSync/tests/handler.test.js
@@ -164,4 +164,21 @@ describe('Lambda handler', () => {
 			context: {},
 		});
 	});
+
+	it('should pass acceptTime as empty string to telephony API when ConnectedToAgentTimestamp is null', async () => {
+		const mockInvoke = jest.fn().mockReturnValue({ promise: () => Promise.resolve({}) });
+		jest.isolateModules(() => {
+			jest.doMock('aws-sdk', () => ({ Lambda: jest.fn(() => ({ invoke: mockInvoke })) }));
+			const ctr = JSON.stringify({
+				ContactId: "test-id", DisconnectReason: "AGENT_HUNGUP",
+				InitiationMethod: "INBOUND", Channel: "VOICE",
+				Agent: { ConnectedToAgentTimestamp: null }
+			});
+			const event = { Records: [{ kinesis: { data: Buffer.from(ctr).toString('base64') } }] };
+			require('../handler').handler(event).then(() => {
+				const payload = JSON.parse(mockInvoke.mock.calls[0][0].Payload);
+				expect(payload.Details.Parameters.fieldValues.acceptTime).toBe("");
+			});
+		});
+	});
 });

--- a/ctrDataSync/tests/utils.test.js
+++ b/ctrDataSync/tests/utils.test.js
@@ -309,6 +309,15 @@ describe('transformCTR', () => {
             expect(resultNoLocation.fields.recordingLocation).toBeUndefined();
         });
     });
+
+    it('should set acceptTime to empty string when ConnectedToAgentTimestamp is null', () => {
+        const result = utils.transformCTR({
+            ContactId: "null-accept-time-test",
+            DisconnectReason: "AGENT_HUNGUP",
+            Agent: { ConnectedToAgentTimestamp: null }
+        });
+        expect(result.fields.acceptTime).toBe("");
+    });
 });
 
 describe('getCallAttributes', () => {

--- a/ctrDataSync/utils.js
+++ b/ctrDataSync/utils.js
@@ -56,7 +56,7 @@ function transformCTR(ctr) {
     voiceCall.secretName = ctr?.Attributes?.secretName
   }
   if (ctr.Agent) {
-    voiceCall.acceptTime = ctr.Agent.ConnectedToAgentTimestamp;
+    voiceCall.acceptTime = ctr.Agent.ConnectedToAgentTimestamp || "";
     voiceCall.totalHoldDuration = ctr.Agent.CustomerHoldDuration;
     voiceCall.longestHoldDuration = ctr.Agent.LongestHoldDuration;
     voiceCall.agentInteractionDuration = ctr.Agent.AgentInteractionDuration;

--- a/healthCheck/utils/placeholder_utils.py
+++ b/healthCheck/utils/placeholder_utils.py
@@ -260,7 +260,6 @@ def fix_multiorg_role_references(text: str, replacements: Dict[str, str]) -> str
     role_mappings = {
         "MultiorgMigrationRole.Arn": f"arn:{partition}:iam::{account_id}:role/{lambda_prefix}-MultiorgMigrationRole",
         "MultiorgInvokeTelephonyIntegrationApiFunctionRoleResource.Arn": f"arn:{partition}:iam::{account_id}:role/{lambda_prefix}-InvokeTelephonyIntegrationApiFunctionRole",
-        "MultiorgInvokeVfsIntegrationApiFunctionRoleResource.Arn": f"arn:{partition}:iam::{account_id}:role/{lambda_prefix}-InvokeVfsIntegrationApiFunctionRole",
         "MultiorgContactDataSyncFunctionRoleResource.Arn": f"arn:{partition}:iam::{account_id}:role/{lambda_prefix}-ContactDataSyncFunctionRole",
         "MultiorgPostCallAnalysisTriggerFunctionRoleResource.Arn": f"arn:{partition}:iam::{account_id}:role/{lambda_prefix}-PostCallAnalysisTriggerFunctionRole",
         "MultiorgInvokeSalesforceRestApiFunctionRoleResource.Arn": f"arn:{partition}:iam::{account_id}:role/{lambda_prefix}-InvokeSalesforceRestApiFunctionRole",

--- a/invokeSfRestApi/package.json
+++ b/invokeSfRestApi/package.json
@@ -7,8 +7,8 @@
   "dependencies": {
     "aws-sdk": "2.1354.0",
     "winston": "3.2.1",
-    "axios": "1.13.6",
-    "axios-logger": "2.5.0",
+    "axios": "1.18.1",
+    "axios-logger": "2.8.1",
     "flat": "5.0.2",
     "jsonwebtoken": "9.0.3",
     "uuid": "3.4.0"

--- a/invokeTelephonyIntegrationApi/handler.js
+++ b/invokeTelephonyIntegrationApi/handler.js
@@ -64,8 +64,11 @@ exports.handler = async (event) => {
 
   let result = {};
   let voiceCallFieldValues;
-  const { methodName, fieldValues, contactId } = event.Details.Parameters;
+  const { methodName, fieldValues, contactId, agentARN } = event.Details.Parameters;
   const contactIdValue = contactId || event.Details.ContactData.ContactId;
+  // for outbound calls, amazon creates 2 contact events when setDisconnectFlow block is hit. we need to take the one which is stored as vendorCallkey in the database.
+  const initialContactIdValue = contactId || event.Details.ContactData.InitialContactId;
+  const toPhoneNumberValue = event.Details.ContactData?.SystemEndpoint?.Address;
   const callOrigin = event.Details.ContactData?.Attributes?.callOrigin || "";
   
   // Extract secret name from call attributes with precedence over environment variable
@@ -227,6 +230,43 @@ exports.handler = async (event) => {
           contactId: contactIdValue
         };
       }
+      break;
+    case "getVoicemailDrop":
+      result = await api.getVoicemailDrop(initialContactIdValue, configData);
+      break;
+    case "getDefaultOutboundPhoneNumber":
+      if (!agentARN) {
+        SCVLoggingUtil.error({
+          message: "agentARN is required for getDefaultOutboundPhoneNumber",
+          context: { contactId: contactIdValue },
+        });
+        throw new Error("agentARN is required for getDefaultOutboundPhoneNumber");
+      }
+      result = await api.getDefaultOutboundPhoneNumber(agentARN, configData);
+      break;
+    case "getVoicemailGreeting":
+      if (!toPhoneNumberValue) {
+        SCVLoggingUtil.error({
+          message: "toPhoneNumber is required for getVoicemailGreeting",
+          context: { contactId: contactIdValue },
+        });
+        throw new Error("toPhoneNumber is required for getVoicemailGreeting");
+      }
+      result = await api.getVoicemailGreeting(toPhoneNumberValue, configData);
+      break;
+    case "reserveRoutableNumber":
+      result = await api.reserveRoutableNumber(
+        event.Details.Parameters,
+        event.Details.ContactData?.Attributes,
+        configData
+      );
+      break;
+    case "createVoiceCallContext":
+      result = await api.createVoiceCallContext(
+        event.Details.Parameters,
+        event.Details.ContactData?.Attributes,
+        configData
+      );
       break;
     case "getJwtToken":
       const jwt = await utils.generateJWT({

--- a/invokeTelephonyIntegrationApi/package.json
+++ b/invokeTelephonyIntegrationApi/package.json
@@ -7,8 +7,8 @@
   "dependencies": {
     "aws-sdk": "2.1354.0",
     "winston": "3.2.1",
-    "axios": "1.13.6",
-    "axios-logger": "2.5.0",
+    "axios": "1.18.1",
+    "axios-logger": "2.8.1",
     "jsonwebtoken": "9.0.3",
     "uuid": "3.4.0"
   },

--- a/invokeTelephonyIntegrationApi/telephonyIntegrationApi.js
+++ b/invokeTelephonyIntegrationApi/telephonyIntegrationApi.js
@@ -376,6 +376,299 @@ async function routeVoiceCall(contactId, payload, configData) {
   return responseVal.data;
 }
 
+/**
+ * Issue an authenticated GET to the SCRT voiceCalls API and surface a typed result.
+ *
+ * @param {string} path - Path under the SCRT endpoint (already URL-encoded).
+ * @param {object} configData - Configuration data containing orgId, callCenterApiName, privateKey, etc.
+ * @param {object} options
+ * @param {string} options.successMessage - Info-log message on a 2xx response.
+ * @param {string} options.errorMessage - Thrown Error message; also the error-log message when `errorLogMessage` is not set.
+ * @param {string} [options.errorLogMessage] - Overrides the error-log message (use to inject request-specific context).
+ * @param {object} [options.notFoundFallback] - When set, a 404 returns `value` instead of throwing.
+ * @param {string} options.notFoundFallback.message - Info-log message for the 404 path.
+ * @param {object} options.notFoundFallback.context - Logging context for the 404 path.
+ * @param {*}      options.notFoundFallback.value - Value to return on 404.
+ */
+async function fetchFromScrt(path, configData, { successMessage, errorMessage, errorLogMessage, notFoundFallback }) {
+  const jwt = await utils.generateJWT({
+    orgId: configData.orgId,
+    callCenterApiName: configData.callCenterApiName,
+    expiresIn: configData.tokenValidFor,
+    privateKey: configData.privateKey,
+  });
+
+  try {
+    const responseVal = await axiosWrapper.getScrtEndpoint(configData)
+      .get(path, {
+        headers: {
+          Authorization: `Bearer ${jwt}`,
+          "Content-Type": "application/json",
+          "Telephony-Provider-Name": vendorFQN,
+        },
+      });
+    SCVLoggingUtil.info({
+      message: successMessage,
+      context: { payload: responseVal },
+    });
+    return responseVal.data;
+  } catch (error) {
+    if (notFoundFallback && error.response?.status === 404) {
+      SCVLoggingUtil.info({
+        message: notFoundFallback.message,
+        context: notFoundFallback.context,
+      });
+      return notFoundFallback.value;
+    }
+    SCVLoggingUtil.error({
+      message: errorLogMessage || errorMessage,
+      context: { payload: error },
+    });
+    throw new Error(errorMessage);
+  }
+}
+
+async function getVoicemailDrop(contactId, configData) {
+  SCVLoggingUtil.info({
+    message: "getVoicemailDrop Request created",
+    context: { contactId: contactId },
+  });
+  return fetchFromScrt(`/voiceCalls/${contactId}/voicemailDrop`, configData, {
+    successMessage: `Successfully retrieved voicemail drop for ${contactId}`,
+    errorMessage: "Error getting voicemail drop",
+    errorLogMessage: `Error getting voicemail drop for ${contactId}`,
+    notFoundFallback: {
+      message: `Voicemail drop not found for ${contactId}`,
+      context: { contactId },
+      value: { recordingUrl: "Not found" },
+    },
+  });
+}
+
+async function getDefaultOutboundPhoneNumber(externalRepId, configData) {
+  SCVLoggingUtil.info({
+    message: "getDefaultOutboundPhoneNumber Request created",
+    context: { externalRepId: externalRepId },
+  });
+  const url = `/voiceCalls/defaultOutboundPhoneNumber?externalRepId=${encodeURIComponent(
+    externalRepId
+  )}`;
+  return fetchFromScrt(url, configData, {
+    successMessage: "Successfully retrieved default outbound phone number",
+    errorMessage: "Error getting default outbound phone number",
+  });
+}
+
+/**
+ * Reserve a routable PSTN number. Resolves and validates inputs from the
+ * contact-flow parameters (with optional fallback to contact attributes),
+ * builds the SCRT2 request body, posts it to /voiceCalls/reserveRoutableNumber,
+ * and returns the response data.
+ *
+ * @param {object} parameters - event.Details.Parameters. Must contain fromNumber (E.164), toNumber, countryCode.
+ * @param {object} [attributes] - event.Details.ContactData.Attributes. Used as fallback for countryCode, callId, transactionId.
+ * @param {object} configData - Configuration data containing orgId, callCenterApiName, privateKey, scrtEndpointBase, tokenValidFor.
+ *
+ * @return {object} - Shaped response: { statusCode, routableNumber, uid, expiresAt, mode }.
+ */
+async function reserveRoutableNumber(parameters, attributes, configData) {
+  const params = parameters || {};
+  const attrs = attributes || {};
+
+  const fromNumber = params.fromNumber;
+  const toNumber = params.toNumber;
+
+  if (!fromNumber || !utils.isValidE164(fromNumber)) {
+    throw new Error(
+      `Invalid or missing fromNumber: ${fromNumber}. Must be E.164 format.`
+    );
+  }
+
+  if (!toNumber || !utils.isValidE164(toNumber)) {
+    throw new Error(
+      `Invalid or missing toNumber: ${toNumber}. Must be E.164 format.`
+    );
+  }
+
+  const countryCode = params.countryCode || attrs.countryCode;
+  if (!countryCode) {
+    throw new Error("countryCode is required for reserveRoutableNumber");
+  }
+
+  const callId = params.callId || attrs.callId || null;
+  const transactionId = params.transactionId || attrs.transactionId || null;
+  const originalFromNumber =
+    params.originalFromNumber || attrs.originalFromNumber || null;
+
+  if (originalFromNumber && !utils.isValidE164(originalFromNumber)) {
+    throw new Error(
+      `Invalid originalFromNumber: ${originalFromNumber}. Must be E.164 format.`
+    );
+  }
+
+  const context = {
+    scrt2Domain: new URL(configData.scrtEndpointBase).origin,
+    toNumber,
+  };
+  if (callId) context.callId = callId;
+  if (transactionId) context.transactionId = transactionId;
+  if (originalFromNumber) context.originalFromNumber = originalFromNumber;
+
+  const payload = { countryCode, fromNumber, context };
+
+  SCVLoggingUtil.info({
+    message: "reserveRoutableNumber request created",
+    context: { countryCode: payload.countryCode, fromNumber: payload.fromNumber },
+  });
+
+  const jwt = await utils.generateJWT({
+    orgId: configData.orgId,
+    callCenterApiName: configData.callCenterApiName,
+    expiresIn: configData.tokenValidFor,
+    privateKey: configData.privateKey,
+  });
+
+  const response = await axiosWrapper.getScrtEndpoint(configData)
+    .post("/voiceCalls/reserveRoutableNumber", payload, {
+      headers: {
+        Authorization: `Bearer ${jwt}`,
+        "Content-Type": "application/json",
+        "Telephony-Provider-Name": vendorFQN,
+      },
+    })
+    .catch((error) => {
+      const status = error.response?.status;
+      const retryAfter = error.response?.headers?.["retry-after"];
+      SCVLoggingUtil.error({
+        message: "Error reserving routable number",
+        context: {
+          status,
+          retryAfter,
+          data: error.response?.data,
+          error: error.message,
+        },
+      });
+      const err = new Error("Error reserving routable number");
+      err.status = status;
+      err.retryAfter = retryAfter;
+      err.responseData = error.response?.data;
+      throw err;
+    });
+
+  const data = response.data || {};
+  const handle = data.handle || {};
+  return {
+    statusCode: 200,
+    routableNumber: handle.routableNumber,
+    uid: handle.uid,
+    expiresAt: handle.expiresAt,
+    mode: data.mode,
+  };
+}
+
+/**
+ * Reserve a server-minted correlation-id handle for a voice call transfer.
+ * Posts to /voiceCalls/createVoiceCallContext with the minimal required body:
+ *   { fromNumber, context: { scrt2Domain, toNumber, callId } }
+ *
+ * @param {object} parameters - event.Details.Parameters. Must contain fromNumber (E.164), toNumber.
+ * @param {object} [attributes] - event.Details.ContactData.Attributes. Fallback source for callId, transactionId.
+ * @param {object} configData - orgId, callCenterApiName, privateKey, scrtEndpointBase, tokenValidFor.
+ *
+ * @return {object} - Shaped response: { statusCode, correlationId, expiresAt, mode }.
+ */
+async function createVoiceCallContext(parameters, attributes, configData) {
+  const params = parameters || {};
+  const attrs = attributes || {};
+
+  const fromNumber = params.fromNumber;
+  const toNumber = params.toNumber;
+  const callId = params.callId || attrs.callId || null;
+  const transactionId = params.transactionId || attrs.transactionId || null;
+
+  if (!fromNumber || !utils.isValidE164(fromNumber)) {
+    throw new Error(
+      `Invalid or missing fromNumber: ${fromNumber}. Must be E.164 format.`
+    );
+  }
+  if (!toNumber || !utils.isValidE164(toNumber)) {
+    throw new Error(
+      `Invalid or missing toNumber: ${toNumber}. Must be E.164 format.`
+    );
+  }
+
+  const context = {
+    scrt2Domain: new URL(configData.scrtEndpointBase).origin,
+    toNumber,
+  };
+  if (callId) context.callId = callId;
+  if (transactionId) context.transactionId = transactionId;
+
+  const payload = { fromNumber, context };
+
+  SCVLoggingUtil.info({
+    message: "createVoiceCallContext request created",
+    context: { fromNumber, toNumber, callId },
+  });
+
+  const jwt = await utils.generateJWT({
+    orgId: configData.orgId,
+    callCenterApiName: configData.callCenterApiName,
+    expiresIn: configData.tokenValidFor,
+    privateKey: configData.privateKey,
+  });
+
+  const response = await axiosWrapper.getScrtEndpoint(configData)
+    .post("/voiceCalls/createVoiceCallContext", payload, {
+      headers: {
+        Authorization: `Bearer ${jwt}`,
+        "Content-Type": "application/json",
+        "Telephony-Provider-Name": vendorFQN,
+      },
+    })
+    .catch((error) => {
+      const status = error.response?.status;
+      const retryAfter = error.response?.headers?.["retry-after"];
+      SCVLoggingUtil.error({
+        message: "Error creating voice call context",
+        context: {
+          status,
+          retryAfter,
+          data: error.response?.data,
+          error: error.message,
+        },
+      });
+      const err = new Error("Error creating voice call context");
+      err.status = status;
+      err.retryAfter = retryAfter;
+      err.responseData = error.response?.data;
+      throw err;
+    });
+
+  const data = response.data || {};
+  const handle = data.handle || {};
+  return {
+    statusCode: 200,
+    correlationId: handle.correlationId,
+    expiresAt: handle.expiresAt,
+    mode: data.mode,
+  };
+}
+
+async function getVoicemailGreeting(toPhoneNumber, configData) {
+  SCVLoggingUtil.info({
+    message: "getVoicemailGreeting Request created",
+    context: { toPhoneNumber: toPhoneNumber },
+  });
+  const url = `/voiceCalls/voicemailGreeting?toPhoneNumber=${encodeURIComponent(
+    toPhoneNumber
+  )}`;
+  return fetchFromScrt(url, configData, {
+    successMessage: "Successfully retrieved voicemail greeting",
+    errorMessage: "Error getting voicemail greeting",
+  });
+}
+
 module.exports = {
   createVoiceCall,
   updateVoiceCall,
@@ -384,5 +677,10 @@ module.exports = {
   cancelOmniFlowExecution,
   rerouteFlowExecution,
   callbackExecution,
-  routeVoiceCall
+  routeVoiceCall,
+  getVoicemailDrop,
+  getDefaultOutboundPhoneNumber,
+  getVoicemailGreeting,
+  reserveRoutableNumber,
+  createVoiceCallContext,
 };

--- a/invokeTelephonyIntegrationApi/tests/handler.test.js
+++ b/invokeTelephonyIntegrationApi/tests/handler.test.js
@@ -878,6 +878,230 @@ describe("handler.js", () => {
       });
     });
 
+    describe("getVoicemailDrop", () => {
+      it("should get voicemail drop with InitialContactId", async () => {
+        const event = {
+          "detail-type": "test",
+          Details: {
+            Parameters: {
+              methodName: "getVoicemailDrop",
+            },
+            ContactData: {
+              ContactId: "test-contact-id",
+              InitialContactId: "test-initial-contact-id",
+            },
+          },
+        };
+
+        const mockResponse = { recordingUrl: "https://s3.amazonaws.com/recording.wav" };
+        api.getVoicemailDrop.mockResolvedValue(mockResponse);
+
+        const result = await handler.handler(event);
+
+        expect(api.getVoicemailDrop).toHaveBeenCalledWith(
+          "test-initial-contact-id",
+          mockSecretConfig
+        );
+        expect(result).toEqual(mockResponse);
+      });
+
+      it("should use contactId from parameters when provided for getVoicemailDrop", async () => {
+        const event = {
+          "detail-type": "test",
+          Details: {
+            Parameters: {
+              methodName: "getVoicemailDrop",
+              contactId: "custom-contact-id",
+            },
+            ContactData: {
+              ContactId: "test-contact-id",
+              InitialContactId: "test-initial-contact-id",
+            },
+          },
+        };
+
+        const mockResponse = { recordingUrl: "https://s3.amazonaws.com/recording.wav" };
+        api.getVoicemailDrop.mockResolvedValue(mockResponse);
+
+        const result = await handler.handler(event);
+
+        expect(api.getVoicemailDrop).toHaveBeenCalledWith(
+          "custom-contact-id",
+          mockSecretConfig
+        );
+        expect(result).toEqual(mockResponse);
+      });
+
+      it("should handle error when getting voicemail drop", async () => {
+        const event = {
+          "detail-type": "test",
+          Details: {
+            Parameters: {
+              methodName: "getVoicemailDrop",
+            },
+            ContactData: {
+              ContactId: "test-contact-id",
+              InitialContactId: "test-contact-id",
+            },
+          },
+        };
+
+        api.getVoicemailDrop.mockRejectedValue(
+          new Error("Error getting voicemail drop")
+        );
+
+        await expect(handler.handler(event)).rejects.toThrow(
+          "Error getting voicemail drop"
+        );
+      });
+    });
+
+    describe("getDefaultOutboundPhoneNumber", () => {
+      it("should get default outbound phone number with agentARN from event Details Parameters", async () => {
+        const event = {
+          "detail-type": "test",
+          Details: {
+            Parameters: {
+              methodName: "getDefaultOutboundPhoneNumber",
+              agentARN: "arn:aws:connect:us-east-1:123456789012:instance/xxx/agent/yyy",
+            },
+            ContactData: {
+              ContactId: "test-contact-id",
+              InitialContactId: "test-contact-id",
+            },
+          },
+        };
+
+        const mockResponse = { phoneNumber: "+15551234567" };
+        api.getDefaultOutboundPhoneNumber.mockResolvedValue(mockResponse);
+
+        const result = await handler.handler(event);
+
+        expect(api.getDefaultOutboundPhoneNumber).toHaveBeenCalledWith(
+          "arn:aws:connect:us-east-1:123456789012:instance/xxx/agent/yyy",
+          mockSecretConfig
+        );
+        expect(result).toEqual(mockResponse);
+      });
+
+      it("should throw when agentARN is missing for getDefaultOutboundPhoneNumber", async () => {
+        const event = {
+          "detail-type": "test",
+          Details: {
+            Parameters: {
+              methodName: "getDefaultOutboundPhoneNumber",
+            },
+            ContactData: {
+              ContactId: "test-contact-id",
+              InitialContactId: "test-contact-id",
+            },
+          },
+        };
+
+        await expect(handler.handler(event)).rejects.toThrow(
+          "agentARN is required for getDefaultOutboundPhoneNumber"
+        );
+        expect(api.getDefaultOutboundPhoneNumber).not.toHaveBeenCalled();
+      });
+
+      it("should handle error when getting default outbound phone number", async () => {
+        const event = {
+          "detail-type": "test",
+          Details: {
+            Parameters: {
+              methodName: "getDefaultOutboundPhoneNumber",
+              agentARN: "arn:aws:connect:us-east-1:123456789012:instance/xxx/agent/yyy",
+            },
+            ContactData: {
+              ContactId: "test-contact-id",
+              InitialContactId: "test-contact-id",
+            },
+          },
+        };
+
+        api.getDefaultOutboundPhoneNumber.mockRejectedValue(
+          new Error("Error getting default outbound phone number")
+        );
+
+        await expect(handler.handler(event)).rejects.toThrow(
+          "Error getting default outbound phone number"
+        );
+      });
+    });
+
+    describe("getVoicemailGreeting", () => {
+      it("should get voicemail greeting with toPhoneNumber from ContactData.SystemEndpoint.Address", async () => {
+        const event = {
+          "detail-type": "test",
+          Details: {
+            Parameters: {
+              methodName: "getVoicemailGreeting",
+            },
+            ContactData: {
+              ContactId: "test-contact-id",
+              InitialContactId: "test-contact-id",
+              SystemEndpoint: { Address: "+15553334444" },
+            },
+          },
+        };
+
+        const mockResponse = { greetingUrl: "https://s3.example.com/greeting.wav" };
+        api.getVoicemailGreeting.mockResolvedValue(mockResponse);
+
+        const result = await handler.handler(event);
+
+        expect(api.getVoicemailGreeting).toHaveBeenCalledWith(
+          "+15553334444",
+          mockSecretConfig
+        );
+        expect(result).toEqual(mockResponse);
+      });
+
+      it("should throw when toPhoneNumber is missing for getVoicemailGreeting (no SystemEndpoint.Address)", async () => {
+        const event = {
+          "detail-type": "test",
+          Details: {
+            Parameters: {
+              methodName: "getVoicemailGreeting",
+            },
+            ContactData: {
+              ContactId: "test-contact-id",
+              InitialContactId: "test-contact-id",
+            },
+          },
+        };
+
+        await expect(handler.handler(event)).rejects.toThrow(
+          "toPhoneNumber is required for getVoicemailGreeting"
+        );
+        expect(api.getVoicemailGreeting).not.toHaveBeenCalled();
+      });
+
+      it("should handle error when getting voicemail greeting", async () => {
+        const event = {
+          "detail-type": "test",
+          Details: {
+            Parameters: {
+              methodName: "getVoicemailGreeting",
+            },
+            ContactData: {
+              ContactId: "test-contact-id",
+              InitialContactId: "test-contact-id",
+              SystemEndpoint: { Address: "+15551234567" },
+            },
+          },
+        };
+
+        api.getVoicemailGreeting.mockRejectedValue(
+          new Error("Error getting voicemail greeting")
+        );
+
+        await expect(handler.handler(event)).rejects.toThrow(
+          "Error getting voicemail greeting"
+        );
+      });
+    });
+
     describe("secret configuration", () => {
       it("should use secret name from call attributes when provided", async () => {
         const event = {
@@ -1002,6 +1226,174 @@ describe("handler.js", () => {
       });
 
 
+    });
+
+    describe("reserveRoutableNumber", () => {
+      it("should delegate to api with parameters, attributes and configData, and return its result", async () => {
+        const parameters = {
+          methodName: "reserveRoutableNumber",
+          countryCode: "US",
+          fromNumber: "+11800999932",
+          toNumber: "+15551234567",
+          callId: "0LQLT000001jmnt",
+          transactionId: "tx-123",
+        };
+        const attributes = { someAttr: "x" };
+        const event = {
+          "detail-type": "test",
+          Details: {
+            Parameters: parameters,
+            ContactData: { ContactId: "test-contact-id", Attributes: attributes },
+          },
+        };
+        const shapedResponse = {
+          statusCode: 200,
+          routableNumber: "+14155560999",
+          uid: "uid-1",
+          expiresAt: "2026-06-23T00:00:00Z",
+          mode: "number",
+        };
+        api.reserveRoutableNumber.mockResolvedValue(shapedResponse);
+
+        const result = await handler.handler(event);
+
+        expect(api.reserveRoutableNumber).toHaveBeenCalledWith(
+          parameters,
+          attributes,
+          mockSecretConfig
+        );
+        expect(result).toEqual(shapedResponse);
+      });
+
+      it("should pass undefined attributes when ContactData has no Attributes", async () => {
+        const parameters = {
+          methodName: "reserveRoutableNumber",
+          countryCode: "US",
+          fromNumber: "+11800999932",
+          toNumber: "+15551234567",
+        };
+        const event = {
+          "detail-type": "test",
+          Details: {
+            Parameters: parameters,
+            ContactData: { ContactId: "test-contact-id" },
+          },
+        };
+        api.reserveRoutableNumber.mockResolvedValue({
+          statusCode: 200,
+          routableNumber: "+14155560999",
+          uid: "u",
+          expiresAt: "z",
+          mode: "number",
+        });
+
+        await handler.handler(event);
+
+        expect(api.reserveRoutableNumber).toHaveBeenCalledWith(
+          parameters,
+          undefined,
+          mockSecretConfig
+        );
+      });
+
+      it("should propagate errors thrown by the API", async () => {
+        const event = {
+          "detail-type": "test",
+          Details: {
+            Parameters: { methodName: "reserveRoutableNumber" },
+            ContactData: { ContactId: "test-contact-id" },
+          },
+        };
+        api.reserveRoutableNumber.mockRejectedValue(
+          new Error("Invalid or missing fromNumber: undefined. Must be E.164 format.")
+        );
+
+        await expect(handler.handler(event)).rejects.toThrow(
+          /Invalid or missing fromNumber/
+        );
+      });
+    });
+
+    describe("createVoiceCallContext", () => {
+      it("should delegate to api with parameters, attributes and configData, and return its result", async () => {
+        const parameters = {
+          methodName: "createVoiceCallContext",
+          fromNumber: "+14155551111",
+          toNumber: "+15551234567",
+          callId: "0LQxx0000004ABcGAM",
+        };
+        const attributes = { someAttr: "x" };
+        const event = {
+          "detail-type": "test",
+          Details: {
+            Parameters: parameters,
+            ContactData: { ContactId: "test-contact-id", Attributes: attributes },
+          },
+        };
+        const shapedResponse = {
+          statusCode: 200,
+          correlationId: "a3f2c4d8-9b7e-4c6f-8e1d-2f5a9c3b7e4d",
+          expiresAt: "2026-07-15T18:45:11Z",
+          mode: "correlationID",
+        };
+        api.createVoiceCallContext.mockResolvedValue(shapedResponse);
+
+        const result = await handler.handler(event);
+
+        expect(api.createVoiceCallContext).toHaveBeenCalledWith(
+          parameters,
+          attributes,
+          mockSecretConfig
+        );
+        expect(result).toEqual(shapedResponse);
+      });
+
+      it("should pass undefined attributes when ContactData has no Attributes", async () => {
+        const parameters = {
+          methodName: "createVoiceCallContext",
+          fromNumber: "+14155551111",
+          toNumber: "+15551234567",
+          callId: "0LQxx0000004ABcGAM",
+        };
+        const event = {
+          "detail-type": "test",
+          Details: {
+            Parameters: parameters,
+            ContactData: { ContactId: "test-contact-id" },
+          },
+        };
+        api.createVoiceCallContext.mockResolvedValue({
+          statusCode: 200,
+          correlationId: "c",
+          expiresAt: "z",
+          mode: "correlationID",
+        });
+
+        await handler.handler(event);
+
+        expect(api.createVoiceCallContext).toHaveBeenCalledWith(
+          parameters,
+          undefined,
+          mockSecretConfig
+        );
+      });
+
+      it("should propagate errors thrown by the API", async () => {
+        const event = {
+          "detail-type": "test",
+          Details: {
+            Parameters: { methodName: "createVoiceCallContext" },
+            ContactData: { ContactId: "test-contact-id" },
+          },
+        };
+        api.createVoiceCallContext.mockRejectedValue(
+          new Error("Invalid or missing fromNumber: undefined. Must be E.164 format.")
+        );
+
+        await expect(handler.handler(event)).rejects.toThrow(
+          /Invalid or missing fromNumber/
+        );
+      });
     });
 
     describe("getJwtToken", () => {

--- a/invokeTelephonyIntegrationApi/tests/telephonyIntegrationApi.test.js
+++ b/invokeTelephonyIntegrationApi/tests/telephonyIntegrationApi.test.js
@@ -7,9 +7,11 @@ const axiosWrapper = require('../axiosWrapper');
 // Mock the axiosWrapper methods
 const mockPost = jest.fn();
 const mockPatch = jest.fn();
+const mockGet = jest.fn();
 axiosWrapper.getScrtEndpoint = jest.fn(() => ({
   post: mockPost,
-  patch: mockPatch
+  patch: mockPatch,
+  get: mockGet
 }));
 
 jest.mock('../utils');
@@ -642,6 +644,633 @@ describe('telephonyIntegrationApi', () => {
         context: { payload: mockAxiosResponse }
       });
       expect(result).toEqual(expectedResponse);
+    });
+  });
+
+  describe('getVoicemailDrop', () => {
+    const contactId = 'test-contact-id';
+
+    it('should successfully get voicemail drop', async () => {
+      const expectedResponse = { recordingUrl: 'https://s3.amazonaws.com/voicemail-recordings/recording.wav' };
+      const mockAxiosResponse = { data: expectedResponse };
+      utils.generateJWT.mockResolvedValue('test-jwt-token');
+      mockGet.mockResolvedValue(mockAxiosResponse);
+
+      const result = await api.getVoicemailDrop(contactId, mockConfigData);
+
+      verifyGenerateJWT();
+      expect(mockGet).toHaveBeenCalledWith(
+        `/voiceCalls/${contactId}/voicemailDrop`,
+        {
+          headers: {
+            ...buildAuthHeaders(),
+            'Telephony-Provider-Name': 'amazon-connect'
+          }
+        }
+      );
+      expect(result).toEqual(expectedResponse);
+    });
+
+    it('should return recordingUrl "Not found" when backend returns 404', async () => {
+      const mock404Error = { response: { status: 404 } };
+      utils.generateJWT.mockResolvedValue('test-jwt-token');
+      mockGet.mockRejectedValue(mock404Error);
+
+      const result = await api.getVoicemailDrop(contactId, mockConfigData);
+
+      expect(result).toEqual({ recordingUrl: 'Not found' });
+      expect(SCVLoggingUtil.info).toHaveBeenCalledWith({
+        message: `Voicemail drop not found for ${contactId}`,
+        context: { contactId }
+      });
+      expect(SCVLoggingUtil.error).not.toHaveBeenCalled();
+    });
+
+    it('should handle error when getting voicemail drop', async () => {
+      const mockError = new Error('API Error');
+      utils.generateJWT.mockResolvedValue('test-jwt-token');
+      mockGet.mockRejectedValue(mockError);
+
+      await expect(api.getVoicemailDrop(contactId, mockConfigData)).rejects.toThrow('Error getting voicemail drop');
+
+      expect(SCVLoggingUtil.error).toHaveBeenCalledWith({
+        message: `Error getting voicemail drop for ${contactId}`,
+        context: { payload: mockError }
+      });
+    });
+
+    it('should throw when backend returns non-404 error status', async () => {
+      const mock500Error = { response: { status: 500 }, message: 'Internal Server Error' };
+      utils.generateJWT.mockResolvedValue('test-jwt-token');
+      mockGet.mockRejectedValue(mock500Error);
+
+      await expect(api.getVoicemailDrop(contactId, mockConfigData)).rejects.toThrow('Error getting voicemail drop');
+
+      expect(SCVLoggingUtil.error).toHaveBeenCalledWith({
+        message: `Error getting voicemail drop for ${contactId}`,
+        context: { payload: mock500Error }
+      });
+    });
+
+    it('should get voicemail drop and verify response data extraction', async () => {
+      const expectedResponse = {
+        recordingUrl: 'https://s3.amazonaws.com/voicemail-recordings/standard-greeting.wav'
+      };
+      const mockAxiosResponse = { data: expectedResponse, status: 200, headers: {} };
+      utils.generateJWT.mockResolvedValue('test-jwt-token');
+      mockGet.mockResolvedValue(mockAxiosResponse);
+
+      const result = await api.getVoicemailDrop(contactId, mockConfigData);
+
+      expect(result).toEqual(expectedResponse);
+      expect(result).not.toHaveProperty('status');
+    });
+  });
+
+  describe('getDefaultOutboundPhoneNumber', () => {
+    const externalRepId = 'arn:aws:connect:us-east-1:123456789012:instance/xxx/agent/yyy';
+
+    it('should successfully get default outbound phone number with externalRepId query param', async () => {
+      const expectedResponse = { phoneNumber: '+15551234567' };
+      const mockAxiosResponse = { data: expectedResponse };
+      utils.generateJWT.mockResolvedValue('test-jwt-token');
+      mockGet.mockResolvedValue(mockAxiosResponse);
+
+      const result = await api.getDefaultOutboundPhoneNumber(externalRepId, mockConfigData);
+
+      verifyGenerateJWT();
+      expect(mockGet).toHaveBeenCalledWith(
+        `/voiceCalls/defaultOutboundPhoneNumber?externalRepId=${encodeURIComponent(externalRepId)}`,
+        {
+          headers: {
+            ...buildAuthHeaders(),
+            'Telephony-Provider-Name': 'amazon-connect'
+          }
+        }
+      );
+      expect(SCVLoggingUtil.info).toHaveBeenCalledWith({
+        message: 'Successfully retrieved default outbound phone number',
+        context: { payload: mockAxiosResponse }
+      });
+      expect(result).toEqual(expectedResponse);
+    });
+
+    it('should handle error when getting default outbound phone number', async () => {
+      const mockError = new Error('API Error');
+      utils.generateJWT.mockResolvedValue('test-jwt-token');
+      mockGet.mockRejectedValue(mockError);
+
+      await expect(
+        api.getDefaultOutboundPhoneNumber(externalRepId, mockConfigData)
+      ).rejects.toThrow('Error getting default outbound phone number');
+
+      expect(SCVLoggingUtil.error).toHaveBeenCalledWith({
+        message: 'Error getting default outbound phone number',
+        context: { payload: mockError }
+      });
+    });
+  });
+
+  describe('getVoicemailGreeting', () => {
+    const toPhoneNumber = '+15551234567';
+
+    it('should successfully get voicemail greeting with query param', async () => {
+      const expectedResponse = { greetingUrl: 'https://s3.example.com/greeting.wav' };
+      const mockAxiosResponse = { data: expectedResponse };
+      utils.generateJWT.mockResolvedValue('test-jwt-token');
+      mockGet.mockResolvedValue(mockAxiosResponse);
+
+      const result = await api.getVoicemailGreeting(toPhoneNumber, mockConfigData);
+
+      verifyGenerateJWT();
+      expect(mockGet).toHaveBeenCalledWith(
+        `/voiceCalls/voicemailGreeting?toPhoneNumber=${encodeURIComponent(toPhoneNumber)}`,
+        {
+          headers: {
+            ...buildAuthHeaders(),
+            'Telephony-Provider-Name': 'amazon-connect'
+          }
+        }
+      );
+      expect(SCVLoggingUtil.info).toHaveBeenCalledWith({
+        message: 'Successfully retrieved voicemail greeting',
+        context: { payload: mockAxiosResponse }
+      });
+      expect(result).toEqual(expectedResponse);
+    });
+
+    it('should encode toPhoneNumber in query string', async () => {
+      const numberWithSpecialChars = '+1 (555) 123-4567';
+      const mockAxiosResponse = { data: {} };
+      utils.generateJWT.mockResolvedValue('test-jwt-token');
+      mockGet.mockResolvedValue(mockAxiosResponse);
+
+      await api.getVoicemailGreeting(numberWithSpecialChars, mockConfigData);
+
+      expect(mockGet).toHaveBeenCalledWith(
+        `/voiceCalls/voicemailGreeting?toPhoneNumber=${encodeURIComponent(numberWithSpecialChars)}`,
+        expect.any(Object)
+      );
+    });
+
+    it('should handle error when getting voicemail greeting', async () => {
+      const mockError = new Error('API Error');
+      utils.generateJWT.mockResolvedValue('test-jwt-token');
+      mockGet.mockRejectedValue(mockError);
+
+      await expect(
+        api.getVoicemailGreeting(toPhoneNumber, mockConfigData)
+      ).rejects.toThrow('Error getting voicemail greeting');
+
+      expect(SCVLoggingUtil.error).toHaveBeenCalledWith({
+        message: 'Error getting voicemail greeting',
+        context: { payload: mockError }
+      });
+    });
+  });
+
+  describe('reserveRoutableNumber', () => {
+    const baseParameters = {
+      countryCode: 'US',
+      fromNumber: '+11800999932',
+      toNumber: '+15551234567',
+      callId: '0LQLT000001jmnt',
+      transactionId: 'tx-123',
+    };
+
+    beforeEach(() => {
+      utils.generateJWT.mockResolvedValue('test-jwt-token');
+      utils.isValidE164.mockImplementation(
+        (n) => typeof n === 'string' && /^\+[1-9]\d{1,14}$/.test(n)
+      );
+    });
+
+    it('should validate, build payload, and return a shaped response', async () => {
+      mockPost.mockResolvedValue({
+        data: {
+          handle: { routableNumber: '+14155560999', uid: 'uid-1', expiresAt: '2026-06-09T18:21:28Z' },
+          mode: 'number',
+        },
+      });
+
+      const result = await api.reserveRoutableNumber(baseParameters, {}, mockConfigData);
+
+      verifyGenerateJWT();
+      expect(mockPost).toHaveBeenCalledWith(
+        '/voiceCalls/reserveRoutableNumber',
+        {
+          countryCode: 'US',
+          fromNumber: '+11800999932',
+          context: {
+            scrt2Domain: 'https://test-scrt-endpoint.com',
+            toNumber: '+15551234567',
+            callId: '0LQLT000001jmnt',
+            transactionId: 'tx-123',
+          },
+        },
+        { headers: { ...buildAuthHeaders(), 'Telephony-Provider-Name': 'amazon-connect' } }
+      );
+      expect(result).toEqual({
+        statusCode: 200,
+        routableNumber: '+14155560999',
+        uid: 'uid-1',
+        expiresAt: '2026-06-09T18:21:28Z',
+        mode: 'number',
+      });
+    });
+
+    it('should omit callId and transactionId from context when not provided in params or attributes', async () => {
+      mockPost.mockResolvedValue({ data: { handle: {}, mode: 'number' } });
+
+      await api.reserveRoutableNumber(
+        { countryCode: 'US', fromNumber: '+11800999932', toNumber: '+15551234567' },
+        {},
+        mockConfigData
+      );
+
+      const sentPayload = mockPost.mock.calls[0][1];
+      expect(sentPayload.context).toEqual({
+        scrt2Domain: 'https://test-scrt-endpoint.com',
+        toNumber: '+15551234567',
+      });
+    });
+
+    it('should fall back to attributes for countryCode, callId, transactionId', async () => {
+      mockPost.mockResolvedValue({ data: { handle: {}, mode: 'number' } });
+
+      await api.reserveRoutableNumber(
+        { fromNumber: '+11800999932', toNumber: '+15551234567' },
+        { countryCode: 'GB', callId: 'attr-call-id', transactionId: 'attr-tx-id' },
+        mockConfigData
+      );
+
+      expect(mockPost).toHaveBeenCalledWith(
+        '/voiceCalls/reserveRoutableNumber',
+        expect.objectContaining({
+          countryCode: 'GB',
+          context: expect.objectContaining({
+            callId: 'attr-call-id',
+            transactionId: 'attr-tx-id',
+          }),
+        }),
+        expect.anything()
+      );
+    });
+
+    it('should derive scrt2Domain.origin from configData.scrtEndpointBase even when it has a path', async () => {
+      const customConfig = {
+        ...mockConfigData,
+        scrtEndpointBase: 'https://my-org.salesforce-scrt.com/telephony/v1',
+      };
+      mockPost.mockResolvedValue({ data: { handle: {}, mode: 'number' } });
+
+      await api.reserveRoutableNumber(baseParameters, {}, customConfig);
+
+      expect(mockPost).toHaveBeenCalledWith(
+        '/voiceCalls/reserveRoutableNumber',
+        expect.objectContaining({
+          context: expect.objectContaining({
+            scrt2Domain: 'https://my-org.salesforce-scrt.com',
+          }),
+        }),
+        expect.anything()
+      );
+    });
+
+    it('should throw when fromNumber is missing', async () => {
+      await expect(
+        api.reserveRoutableNumber(
+          { countryCode: 'US', toNumber: '+15551234567' },
+          {},
+          mockConfigData
+        )
+      ).rejects.toThrow(/Invalid or missing fromNumber/);
+      expect(mockPost).not.toHaveBeenCalled();
+    });
+
+    it('should throw when fromNumber is not in E.164 format', async () => {
+      await expect(
+        api.reserveRoutableNumber(
+          { countryCode: 'US', fromNumber: '1800999932', toNumber: '+15551234567' },
+          {},
+          mockConfigData
+        )
+      ).rejects.toThrow(/Invalid or missing fromNumber/);
+      expect(mockPost).not.toHaveBeenCalled();
+    });
+
+    it('should throw when toNumber is missing', async () => {
+      await expect(
+        api.reserveRoutableNumber(
+          { countryCode: 'US', fromNumber: '+11800999932' },
+          {},
+          mockConfigData
+        )
+      ).rejects.toThrow(/Invalid or missing toNumber/);
+      expect(mockPost).not.toHaveBeenCalled();
+    });
+
+    it('should throw when toNumber is not in E.164 format', async () => {
+      await expect(
+        api.reserveRoutableNumber(
+          { countryCode: 'US', fromNumber: '+11800999932', toNumber: '5551234567' },
+          {},
+          mockConfigData
+        )
+      ).rejects.toThrow(/Invalid or missing toNumber/);
+      expect(mockPost).not.toHaveBeenCalled();
+    });
+
+    it('should throw when countryCode is missing from both params and attributes', async () => {
+      await expect(
+        api.reserveRoutableNumber(
+          { fromNumber: '+11800999932', toNumber: '+15551234567' },
+          {},
+          mockConfigData
+        )
+      ).rejects.toThrow('countryCode is required for reserveRoutableNumber');
+      expect(mockPost).not.toHaveBeenCalled();
+    });
+
+    it('should throw a tagged error and log details when POST fails', async () => {
+      const axiosError = new Error('API Error');
+      axiosError.response = {
+        status: 429,
+        headers: { 'retry-after': '30' },
+        data: { code: 'RATE_LIMITED' },
+      };
+      mockPost.mockRejectedValue(axiosError);
+
+      let caught;
+      try {
+        await api.reserveRoutableNumber(baseParameters, {}, mockConfigData);
+      } catch (err) {
+        caught = err;
+      }
+
+      expect(caught).toBeDefined();
+      expect(caught.message).toBe('Error reserving routable number');
+      expect(caught.status).toBe(429);
+      expect(caught.retryAfter).toBe('30');
+      expect(caught.responseData).toEqual({ code: 'RATE_LIMITED' });
+
+      expect(SCVLoggingUtil.error).toHaveBeenCalledWith(
+        expect.objectContaining({
+          message: 'Error reserving routable number',
+          context: expect.objectContaining({
+            status: 429,
+            retryAfter: '30',
+            data: { code: 'RATE_LIMITED' },
+          }),
+        })
+      );
+    });
+
+    it('should propagate originalFromNumber from params to payload.context.originalFromNumber', async () => {
+      mockPost.mockResolvedValue({ data: { handle: {}, mode: 'number' } });
+
+      await api.reserveRoutableNumber(
+        { ...baseParameters, originalFromNumber: '+14155551111' },
+        {},
+        mockConfigData
+      );
+
+      const sentPayload = mockPost.mock.calls[0][1];
+      expect(sentPayload.context.originalFromNumber).toBe('+14155551111');
+    });
+
+    it('should fall back to attributes.originalFromNumber when absent from params', async () => {
+      mockPost.mockResolvedValue({ data: { handle: {}, mode: 'number' } });
+
+      await api.reserveRoutableNumber(
+        { countryCode: 'US', fromNumber: '+11800999932', toNumber: '+15551234567' },
+        { originalFromNumber: '+14155552222' },
+        mockConfigData
+      );
+
+      const sentPayload = mockPost.mock.calls[0][1];
+      expect(sentPayload.context.originalFromNumber).toBe('+14155552222');
+    });
+
+    it('should omit originalFromNumber from context when not provided in params or attributes', async () => {
+      mockPost.mockResolvedValue({ data: { handle: {}, mode: 'number' } });
+
+      await api.reserveRoutableNumber(
+        { countryCode: 'US', fromNumber: '+11800999932', toNumber: '+15551234567' },
+        {},
+        mockConfigData
+      );
+
+      const sentPayload = mockPost.mock.calls[0][1];
+      expect(sentPayload.context).not.toHaveProperty('originalFromNumber');
+    });
+
+    it('should throw when originalFromNumber is present but not E.164, before any POST', async () => {
+      await expect(
+        api.reserveRoutableNumber(
+          { ...baseParameters, originalFromNumber: '4155551111' },
+          {},
+          mockConfigData
+        )
+      ).rejects.toThrow(/Invalid originalFromNumber/);
+      expect(mockPost).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('createVoiceCallContext', () => {
+    const baseParameters = {
+      fromNumber: '+14155551111',
+      toNumber: '+15551234567',
+      callId: '0LQxx0000004ABcGAM',
+    };
+
+    beforeEach(() => {
+      utils.generateJWT.mockResolvedValue('test-jwt-token');
+      utils.isValidE164.mockImplementation(
+        (n) => typeof n === 'string' && /^\+[1-9]\d{1,14}$/.test(n)
+      );
+    });
+
+    it('should validate, build the minimal payload, and return a shaped response', async () => {
+      mockPost.mockResolvedValue({
+        data: {
+          status: 'success',
+          mode: 'correlationID',
+          handle: {
+            correlationId: 'a3f2c4d8-9b7e-4c6f-8e1d-2f5a9c3b7e4d',
+            expiresAt: '2026-07-15T18:45:11Z',
+          },
+        },
+      });
+
+      const result = await api.createVoiceCallContext(baseParameters, {}, mockConfigData);
+
+      verifyGenerateJWT();
+      expect(mockPost).toHaveBeenCalledWith(
+        '/voiceCalls/createVoiceCallContext',
+        {
+          fromNumber: '+14155551111',
+          context: {
+            scrt2Domain: 'https://test-scrt-endpoint.com',
+            toNumber: '+15551234567',
+            callId: '0LQxx0000004ABcGAM',
+          },
+        },
+        { headers: { ...buildAuthHeaders(), 'Telephony-Provider-Name': 'amazon-connect' } }
+      );
+      expect(result).toEqual({
+        statusCode: 200,
+        correlationId: 'a3f2c4d8-9b7e-4c6f-8e1d-2f5a9c3b7e4d',
+        expiresAt: '2026-07-15T18:45:11Z',
+        mode: 'correlationID',
+      });
+    });
+
+    it('should fall back to attributes for callId and transactionId when absent from params', async () => {
+      mockPost.mockResolvedValue({ data: { handle: {}, mode: 'correlationID' } });
+
+      await api.createVoiceCallContext(
+        { fromNumber: '+14155551111', toNumber: '+15551234567' },
+        { callId: 'attr-call-id', transactionId: 'attr-tx-id' },
+        mockConfigData
+      );
+
+      const sentPayload = mockPost.mock.calls[0][1];
+      expect(sentPayload.context.callId).toBe('attr-call-id');
+      expect(sentPayload.context.transactionId).toBe('attr-tx-id');
+    });
+
+    it('should include transactionId in context when provided in params', async () => {
+      mockPost.mockResolvedValue({ data: { handle: {}, mode: 'correlationID' } });
+
+      await api.createVoiceCallContext(
+        { ...baseParameters, transactionId: 'tx-123' },
+        {},
+        mockConfigData
+      );
+
+      const sentPayload = mockPost.mock.calls[0][1];
+      expect(sentPayload.context.transactionId).toBe('tx-123');
+    });
+
+    it('should omit transactionId from context when not provided in params or attributes', async () => {
+      mockPost.mockResolvedValue({ data: { handle: {}, mode: 'correlationID' } });
+
+      await api.createVoiceCallContext(baseParameters, {}, mockConfigData);
+
+      const sentPayload = mockPost.mock.calls[0][1];
+      expect(sentPayload.context).not.toHaveProperty('transactionId');
+    });
+
+    it('should derive scrt2Domain origin from configData.scrtEndpointBase even when it has a path', async () => {
+      const customConfig = {
+        ...mockConfigData,
+        scrtEndpointBase: 'https://my-org.salesforce-scrt.com/telephony/v1',
+      };
+      mockPost.mockResolvedValue({ data: { handle: {}, mode: 'correlationID' } });
+
+      await api.createVoiceCallContext(baseParameters, {}, customConfig);
+
+      const sentPayload = mockPost.mock.calls[0][1];
+      expect(sentPayload.context.scrt2Domain).toBe('https://my-org.salesforce-scrt.com');
+    });
+
+    it('should throw when fromNumber is missing', async () => {
+      await expect(
+        api.createVoiceCallContext(
+          { toNumber: '+15551234567', callId: '0LQxx0000004ABcGAM' },
+          {},
+          mockConfigData
+        )
+      ).rejects.toThrow(/Invalid or missing fromNumber/);
+      expect(mockPost).not.toHaveBeenCalled();
+    });
+
+    it('should throw when fromNumber is not E.164', async () => {
+      await expect(
+        api.createVoiceCallContext(
+          { fromNumber: '4155551111', toNumber: '+15551234567', callId: '0LQxx0000004ABcGAM' },
+          {},
+          mockConfigData
+        )
+      ).rejects.toThrow(/Invalid or missing fromNumber/);
+      expect(mockPost).not.toHaveBeenCalled();
+    });
+
+    it('should throw when toNumber is not E.164', async () => {
+      await expect(
+        api.createVoiceCallContext(
+          { fromNumber: '+14155551111', toNumber: '5551234567', callId: '0LQxx0000004ABcGAM' },
+          {},
+          mockConfigData
+        )
+      ).rejects.toThrow(/Invalid or missing toNumber/);
+      expect(mockPost).not.toHaveBeenCalled();
+    });
+
+    it('should omit callId from context when missing from both params and attributes', async () => {
+      mockPost.mockResolvedValue({ data: { handle: {}, mode: 'correlationID' } });
+
+      await api.createVoiceCallContext(
+        { fromNumber: '+14155551111', toNumber: '+15551234567' },
+        {},
+        mockConfigData
+      );
+
+      const sentPayload = mockPost.mock.calls[0][1];
+      expect(sentPayload.context).toEqual({
+        scrt2Domain: 'https://test-scrt-endpoint.com',
+        toNumber: '+15551234567',
+      });
+    });
+
+    it('should throw a tagged error and log status + retry-after when POST returns 429', async () => {
+      const axiosError = new Error('API Error');
+      axiosError.response = {
+        status: 429,
+        headers: { 'retry-after': '30' },
+        data: { code: 'RATE_LIMITED' },
+      };
+      mockPost.mockRejectedValue(axiosError);
+
+      let caught;
+      try {
+        await api.createVoiceCallContext(baseParameters, {}, mockConfigData);
+      } catch (err) {
+        caught = err;
+      }
+
+      expect(caught).toBeDefined();
+      expect(caught.message).toBe('Error creating voice call context');
+      expect(caught.status).toBe(429);
+      expect(caught.retryAfter).toBe('30');
+      expect(caught.responseData).toEqual({ code: 'RATE_LIMITED' });
+      expect(SCVLoggingUtil.error).toHaveBeenCalledWith(
+        expect.objectContaining({
+          message: 'Error creating voice call context',
+          context: expect.objectContaining({
+            status: 429,
+            retryAfter: '30',
+            data: { code: 'RATE_LIMITED' },
+          }),
+        })
+      );
+    });
+
+    it('should tag error with status 403 when POST returns 403', async () => {
+      const axiosError = new Error('Forbidden');
+      axiosError.response = { status: 403, headers: {}, data: { code: 'PERM_MISSING' } };
+      mockPost.mockRejectedValue(axiosError);
+
+      let caught;
+      try {
+        await api.createVoiceCallContext(baseParameters, {}, mockConfigData);
+      } catch (err) {
+        caught = err;
+      }
+
+      expect(caught.status).toBe(403);
+      expect(caught.responseData).toEqual({ code: 'PERM_MISSING' });
     });
   });
 

--- a/invokeTelephonyIntegrationApi/tests/utils.test.js
+++ b/invokeTelephonyIntegrationApi/tests/utils.test.js
@@ -6,7 +6,7 @@ const jwt = require('jsonwebtoken');
 jest.mock('uuid/v1');
 const uuid = require('uuid');
 
-afterEach(() => {
+afterEach(() => {    
   jest.clearAllMocks();
 });
 
@@ -102,6 +102,14 @@ describe('constructFlowInputParams', () => {
     });
 });
 
+describe('generateTransactionId', () => {
+    it('should return the value produced by uuid()', () => {
+        jest.spyOn(uuid, 'v1').mockReturnValue('test-transaction-id');
+        const result = utils.generateTransactionId();
+        expect(result).toBe('test-transaction-id');
+    });
+});
+
 describe('getCallAttributes', () => {
     it('should filter attributes that start with "sfdc-" prefix, ignore other prefix, handle case, support other characters and data types', () => {
         const input = {
@@ -132,8 +140,8 @@ describe('getCallAttributes', () => {
     it('should handle empty input object', () => {
         const input = {};
         const expected = JSON.stringify({});
-  
+        
         const result = utils.getCallAttributes(input);
         expect(result).toBe(expected);
     });
-});
+}); 

--- a/invokeTelephonyIntegrationApi/utils.js
+++ b/invokeTelephonyIntegrationApi/utils.js
@@ -68,8 +68,30 @@ function constructFlowInputParams(rawFlowInputParams) {
   return flowInputParams;
 }
 
+/**
+ * Generate a unique transaction identifier.
+ *
+ * @return {string} - A UUID string.
+ */
+function generateTransactionId() {
+  return uuid();
+}
+
+/**
+ * Validate that a phone number is in E.164 format.
+ *
+ * @param {string} phoneNumber - The phone number to validate.
+ *
+ * @return {boolean} - True if the phone number is a valid E.164 string.
+ */
+function isValidE164(phoneNumber) {
+  return typeof phoneNumber === "string" && /^\+[1-9]\d{1,14}$/.test(phoneNumber);
+}
+
 module.exports = {
-  generateJWT,
-  getCallAttributes,
-  constructFlowInputParams,
+    generateJWT,
+    getCallAttributes,
+    constructFlowInputParams,
+    generateTransactionId,
+    isValidE164,
 };

--- a/invokeVfsIntegrationApi/package.json
+++ b/invokeVfsIntegrationApi/package.json
@@ -7,8 +7,8 @@
   "dependencies": {
     "aws-sdk": "2.1354.0",
     "winston": "3.2.1",
-    "axios": "1.13.6",
-    "axios-logger": "2.5.0",
+    "axios": "1.18.1",
+    "axios-logger": "2.8.1",
     "jsonwebtoken": "9.0.3",
     "uuid": "3.4.0"
   },

--- a/kvsTranscriber/src/main/java/com/amazonaws/kvstranscribestreaming/TranscribedSegmentWriter.java
+++ b/kvsTranscriber/src/main/java/com/amazonaws/kvstranscribestreaming/TranscribedSegmentWriter.java
@@ -206,9 +206,16 @@ public class TranscribedSegmentWriter {
             con.setRequestProperty("Accept", "application/json");
             con.setRequestProperty("Telephony-Provider-Name", "amazon-connect");
             con.setDoOutput(true);
+
+            SCVLoggingUtil.info("com.amazonaws.kvstranscribestreaming.executeRequest",
+                SCVLoggingUtil.EVENT_TYPE.PERFORMANCE,
+                "Sending HTTP request to SCRT2 endpoint: " + url.getPath(),
+                null);
+
             try (OutputStream os = con.getOutputStream()) {
                 OutputStreamWriter osw = new OutputStreamWriter(os, StandardCharsets.UTF_8);
                 payload.writeJSONString(osw);
+                osw.close();
             }
             return con.getResponseCode();
         } finally {

--- a/kvsTranscriber/src/test/java/com/amazonaws/kvstranscribestreaming/TranscribedSegmentWriterTest.java
+++ b/kvsTranscriber/src/test/java/com/amazonaws/kvstranscribestreaming/TranscribedSegmentWriterTest.java
@@ -434,4 +434,61 @@ public class TranscribedSegmentWriterTest {
             server.stop(0);
         }
     }
+
+    /**
+     * Test to verify that OutputStreamWriter properly flushes buffered data to the server.
+     * This test catches the regression from W-21432978 where removing osw.close() caused
+     * buffered data to never be sent, resulting in HTTP 400 errors from the server.
+     *
+     * Without proper flush/close of the OutputStreamWriter, the JSON payload remains in
+     * the writer's buffer and is never written to the underlying OutputStream, causing
+     * the server to receive incomplete/malformed JSON which it rejects with HTTP 400.
+     */
+    @Test
+    void sendMessage_properlyFlushesBufferedData() throws Exception {
+        // Create server that validates JSON structure like production
+        HttpServer server = HttpServer.create(new InetSocketAddress(0), 0);
+        server.createContext("/", (HttpExchange exchange) -> {
+            try {
+                String body = new String(exchange.getRequestBody().readAllBytes(), java.nio.charset.StandardCharsets.UTF_8);
+
+                // Parse as JSON - this fails if buffer wasn't flushed and JSON is incomplete
+                org.json.simple.parser.JSONParser parser = new org.json.simple.parser.JSONParser();
+                org.json.simple.JSONObject json = (org.json.simple.JSONObject) parser.parse(body);
+
+                // Validate required fields exist
+                if (json.containsKey("messageId") && json.containsKey("content") &&
+                    json.containsKey("participantId") && json.containsKey("senderType")) {
+                    exchange.sendResponseHeaders(HTTP_OK, 0);
+                } else {
+                    exchange.sendResponseHeaders(HTTP_BAD_REQUEST, 0);
+                }
+            } catch (Exception e) {
+                // Malformed/incomplete JSON = 400 (like production behavior)
+                exchange.sendResponseHeaders(HTTP_BAD_REQUEST, 0);
+            }
+            exchange.close();
+        });
+        server.start();
+
+        try {
+            String baseUrl = "http://localhost:" + server.getAddress().getPort() + "/telephony/v1";
+            ConfigManager.SecretConfig mockConfig = createMockConfig(baseUrl);
+            ConnectClient mockConnectClient = mock(ConnectClient.class);
+
+            try (MockedStatic<ConnectClient> connectMock = Mockito.mockStatic(ConnectClient.class)) {
+                connectMock.when(ConnectClient::create).thenReturn(mockConnectClient);
+                TranscribedSegmentWriter tsw = new TranscribedSegmentWriter(
+                        TEST_INSTANCE_ARN, TEST_VOICE_CALL_ID, true, TEST_AUDIO_START, TEST_CUSTOMER_PHONE, mockConfig);
+
+                tsw.sendMessage(TEST_MESSAGE, TEST_MESSAGE_ID, TEST_AUDIO_START, TEST_AUDIO_START + 1000);
+
+                // If we get here without HTTP 400, the JSON was valid and complete
+                // Without close/flush, the JSON would be incomplete and server would return 400
+                verify(mockConnectClient, never()).updateContactAttributes(any(UpdateContactAttributesRequest.class));
+            }
+        } finally {
+            server.stop(0);
+        }
+    }
 }

--- a/layers/contactDataSyncFunctionLayer/nodejs/package.json
+++ b/layers/contactDataSyncFunctionLayer/nodejs/package.json
@@ -6,8 +6,8 @@
   "dependencies": {
     "aws-sdk": "2.1354.0",
     "winston": "3.2.1",
-    "axios": "1.13.6",
-    "axios-logger": "2.5.0",
+    "axios": "1.18.1",
+    "axios-logger": "2.8.1",
     "jsonwebtoken": "9.0.3",
     "uuid": "3.4.0"
   }

--- a/layers/contactLensConsumerFunctionLayer/nodejs/package.json
+++ b/layers/contactLensConsumerFunctionLayer/nodejs/package.json
@@ -6,8 +6,8 @@
   "dependencies": {
     "aws-sdk": "2.1354.0",
     "winston": "3.2.1",
-    "axios": "1.13.6",
-    "axios-logger": "2.5.0",
+    "axios": "1.18.1",
+    "axios-logger": "2.8.1",
     "jsonwebtoken": "9.0.3",
     "uuid": "3.4.0"
   }

--- a/layers/contactLensProcessorFunctionLayer/nodejs/package.json
+++ b/layers/contactLensProcessorFunctionLayer/nodejs/package.json
@@ -6,8 +6,8 @@
   "dependencies": {
     "aws-sdk": "2.1354.0",
     "winston": "3.2.1",
-    "axios": "1.13.6",
-    "axios-logger": "2.5.0",
+    "axios": "1.18.1",
+    "axios-logger": "2.8.1",
     "jsonwebtoken": "9.0.3",
     "uuid": "3.4.0"
   }

--- a/layers/invokeSfRestApiFunctionLayer/nodejs/package.json
+++ b/layers/invokeSfRestApiFunctionLayer/nodejs/package.json
@@ -6,8 +6,8 @@
   "dependencies": {
     "aws-sdk": "2.1354.0",
     "winston": "3.2.1",
-    "axios": "1.13.6",
-    "axios-logger": "2.5.0",
+    "axios": "1.18.1",
+    "axios-logger": "2.8.1",
     "flat": "5.0.2",
     "jsonwebtoken": "9.0.3",
     "uuid": "3.4.0"

--- a/layers/invokeTelephonyIntegrationApiFunctionLayer/nodejs/package.json
+++ b/layers/invokeTelephonyIntegrationApiFunctionLayer/nodejs/package.json
@@ -6,8 +6,8 @@
   "dependencies": {
     "aws-sdk": "2.1354.0",
     "winston": "3.2.1",
-    "axios": "1.13.6",
-    "axios-logger": "2.5.0",
+    "axios": "1.18.1",
+    "axios-logger": "2.8.1",
     "jsonwebtoken": "9.0.3",
     "uuid": "3.4.0"
   }

--- a/layers/invokeVfsIntegrationApiFunctionLayer/nodejs/package.json
+++ b/layers/invokeVfsIntegrationApiFunctionLayer/nodejs/package.json
@@ -6,8 +6,8 @@
   "dependencies": {
     "aws-sdk": "2.1354.0",
     "winston": "3.2.1",
-    "axios": "1.13.6",
-    "axios-logger": "2.5.0",
+    "axios": "1.18.1",
+    "axios-logger": "2.8.1",
     "jsonwebtoken": "9.0.3",
     "uuid": "3.4.0"
   }

--- a/layers/postCallAnalysisTriggerFunctionLayer/nodejs/package.json
+++ b/layers/postCallAnalysisTriggerFunctionLayer/nodejs/package.json
@@ -6,9 +6,9 @@
     "dependencies": {
       "aws-sdk": "2.1354.0",
       "winston": "3.2.1",
-      "axios": "1.13.6",
-      "axios-logger": "2.5.0",
-      "axios-retry": "3.3.1",  
+      "axios": "1.18.1",
+      "axios-logger": "2.8.1",
+      "axios-retry": "3.3.1",
       "jsonwebtoken": "9.0.3",
       "uuid": "3.4.0"
     }

--- a/multiorgContactLensConsumer/package.json
+++ b/multiorgContactLensConsumer/package.json
@@ -10,8 +10,8 @@
   "dependencies": {
     "aws-sdk": "2.1354.0",
     "winston": "3.2.1",
-    "axios": "1.13.6",
-    "axios-logger": "2.5.0",
+    "axios": "1.18.1",
+    "axios-logger": "2.8.1",
     "jsonwebtoken": "9.0.3",
     "uuid": "3.4.0"
   },

--- a/multiorgPostCallAnalysisTrigger/package.json
+++ b/multiorgPostCallAnalysisTrigger/package.json
@@ -7,8 +7,8 @@
   "dependencies": {
     "aws-sdk": "2.1354.0",
     "winston": "3.2.1",
-    "axios": "1.13.6",
-    "axios-logger": "2.5.0",
+    "axios": "1.18.1",
+    "axios-logger": "2.8.1",
     "axios-retry": "3.3.1",
     "jsonwebtoken": "9.0.3",
     "uuid": "3.4.0"

--- a/package.json
+++ b/package.json
@@ -49,8 +49,8 @@
   "dependencies": {
     "aws-param-store": "3.2.0",
     "aws-sdk": "2.1354.0",
-    "axios": "1.13.6",
-    "axios-logger": "2.5.0",
+    "axios": "1.18.1",
+    "axios-logger": "2.8.1",
     "axios-retry": "3.3.1",
     "ebml": "3.0.0",
     "flat": "5.0.2",

--- a/postCallAnalysisTrigger/package.json
+++ b/postCallAnalysisTrigger/package.json
@@ -7,8 +7,8 @@
   "dependencies": {
     "aws-sdk": "2.1354.0",
     "winston": "3.2.1",
-    "axios": "1.13.6",
-    "axios-logger": "2.5.0",
+    "axios": "1.18.1",
+    "axios-logger": "2.8.1",
     "axios-retry": "3.3.1",
     "jsonwebtoken": "9.0.3",
     "uuid": "3.4.0"


### PR DESCRIPTION
Release: CC22.0
invokeTelephonyIntegrationApi: add getVoicemailDrop, getDefaultOutboundPhoneNumber, getVoicemailGreeting, reserveRoutableNumber, and createVoiceCallContext; introduce fetchFromScrt helper, E.164 validation, and InitialContactId handling for outbound; expand handler, API, utils, and tests

cloudformation: remove InvokeVfsIntegrationApi function, layer, IAM role, Connect association, permissions, and CloudWatch alarms from BYOA, tenant, Connect, multiorg, health-check, and realtime-alert stacks

contactLensProcessor: send BulkSendMessages per secretName so multi-tenant batches are not mixed; fix payload construction

ctrDataSync: set acceptTime to empty string when ConnectedToAgentTimestamp is null; add handler and utils tests

kvsTranscriber: close OutputStreamWriter so JSON payload is flushed (W-21432978); add sendMessage flush regression test and SCRT2 request performance log

healthCheck: drop MultiorgInvokeVfsIntegrationApiFunctionRole placeholder mapping

chore: bump axios to 1.18.1 and axios-logger to 2.8.1 across lambdas, layers, and root package.json